### PR TITLE
fix async tests

### DIFF
--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -72,19 +72,19 @@ describe('NavigationComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('sets workspaceRoot initially', () => {
+  it('sets workspaceRoot initially', async(() => {
     fixture.whenStable().then(() => {
       expect(component.workspaceRoot.name).toEqual(listedFile.name);
     });
-  });
+  }));
 
-  it('expands workspaceRoot initially', () => {
+  it('expands workspaceRoot initially', async(() => {
     fixture.whenStable().then(() => {
       expect(component.uiState.isExpanded(listedFile.path)).toBeTruthy();
     });
-  });
+  }));
 
-  it('displays an error when workspace could not be retrieved', () => {
+  it('displays an error when workspace could not be retrieved', async(() => {
     // given
     when(persistenceService.listFiles()).thenReturn(Promise.reject("failed"));
 
@@ -99,7 +99,7 @@ describe('NavigationComponent', () => {
       expect(alert).toBeTruthy();
       expect(alert.nativeElement.innerText).toEqual(component.errorMessage);
     });
-  });
+  }));
 
   it('updates the UI state when an "editor.active" event is received', () => {
     // given

--- a/src/lib/src/component/tree-viewer/new-element.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/new-element.component.spec.ts
@@ -122,7 +122,7 @@ describe('NewElementComponent', () => {
     verify(persistenceService.createDocument("some/path/something-new.txt", ElementType.File)).once();
   });
 
-  it('removes itself and emits navigation.refresh event when createDocument returns', () => {
+  it('removes itself and emits navigation.refresh event when createDocument returns', async(() => {
     // given
     let callback = jasmine.createSpy('callback');
     messagingService.subscribe(events.NAVIGATION_REFRESH, callback);
@@ -137,9 +137,9 @@ describe('NewElementComponent', () => {
       expect(callback).toHaveBeenCalledTimes(1);
       expect(component.uiState.newElementRequest).toBeFalsy();
     });
-  });
+  }));
 
-  it('signals an error when createDocument failed', () => {
+  it('signals an error when createDocument failed', async(() => {
     // given
     when(persistenceService.createDocument(anyString(), anyString())).thenReturn(Promise.reject("failed"));
 
@@ -156,7 +156,7 @@ describe('NewElementComponent', () => {
         expect(alert.nativeElement.innerText).toEqual(component.errorMessage);
       });
     });
-  });
+  }));
 
   it('shows file icon when a new file should be created', () => {
     // given

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -80,7 +80,7 @@ describe('TreeViewerComponent', () => {
     return fixture.debugElement.query(By.css('.tree-view .tree-view-item-key'));
   }
 
-   it('should be created', () => {
+  it('should be created', () => {
     expect(component).toBeTruthy();
   });
 
@@ -94,7 +94,7 @@ describe('TreeViewerComponent', () => {
     expect(component.isEmptyFolder()).toBeTruthy();
   });
 
-  it('folded folder does not display sub elements', () => {
+  it('folded folder does not display sub elements', async(() => {
     // given
     component.model = foldedFolderWithSubfolders;
 
@@ -111,9 +111,9 @@ describe('TreeViewerComponent', () => {
       expect(component.isFolderExpanded()).toBeFalsy(); // make sure it is folded beforehand
       expect(component.isFolderFolded()).toBeTruthy(); // make sure it is folded beforehand
     });
-  });
+  }));
 
-  it('expands folder when UI state is set', () => {
+  it('expands folder when UI state is set', async(() => {
     // given
     component.model = foldedFolderWithSubfolders;
 
@@ -135,7 +135,7 @@ describe('TreeViewerComponent', () => {
       expect(component.isFolderExpanded()).toBeTruthy();
       expect(component.isFolderFolded()).toBeFalsy();
     });
-  });
+  }));
 
   it('sets expanded state when double-clicked', () => {
     // given
@@ -325,7 +325,7 @@ describe('TreeViewerComponent', () => {
     verify(persistenceService.deleteResource(anyString())).never();
   });
 
-  it('displays error when deletion failed', () => {
+  it('displays error when deletion failed', (done: () => void) => {
     // given
     component.model = singleFile;
     when(persistenceService.deleteResource(anyString())).thenReturn(Promise.reject("unsupported"));
@@ -340,11 +340,12 @@ describe('TreeViewerComponent', () => {
         expect(component.errorMessage).toBeTruthy();
         let errorMessage = fixture.debugElement.query(By.css('.tree-view-item .alert'));
         expect(errorMessage).toBeTruthy();
+        done();
       });
     });
   });
 
-  it('removes confirmation and emits navigation.deleted event when deletion succeeds', () => {
+  it('removes confirmation and emits navigation.deleted event when deletion succeeds', async(() => {
     // given
     component.model = singleFile;
     let response = createResponse();
@@ -366,6 +367,6 @@ describe('TreeViewerComponent', () => {
         type: singleFile.type
       }));
     });
-  });
+  }));
 
 });


### PR DESCRIPTION
Tests using:
```
fixture.whenStable().then(() => {
   ...
});
```
need to tell Jasmine to wait for their asynchronous execution.

This can either be done using:
```
  it('some test', async(() => {
   ...
  }));
``` 
or
```
  it('some test', (done: () => void) => {
   ...
    fixture.whenStable().then(() => {
      ...
        done();
      });
  });
```
