### PR TITLE
Feature/add angular jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,37 @@ Angular component and Dropwizard service for workspace handling and navigation.
 
 ## Usage
 
-This library requires `@testeditor/messaging-service` to be present, install both with:
+This library requires additionally `@testeditor/messaging-service` and `angular2-jwt` to be present, install with:
 
-    yarn add @testeditor/workspace-navigator @testeditor/messaging-service
+    yarn add @testeditor/workspace-navigator @testeditor/messaging-service angular2-jwt
 
     // or
     
-    npm install @testeditor/workspace-navigator @testeditor/messaging-service --save
+    npm install @testeditor/workspace-navigator @testeditor/messaging-service angular2-jwt --save
 
-Also the outer application must provide a singleton of `MessageService`. In your root module add the following:
+Also the outer application must provide a singleton of `MessageService`. Additionally `angular2-jwt` needs to be setup.
+In your root module add the following:
 
+    import { HttpModule, Http, RequestOptions } from '@angular/http';
+    
     import { MessagingModule } from '@testeditor/messaging-service';
+    import { AuthHttp, AuthConfig } from 'angular2-jwt';
 
     // ...
+
+    export function authHttpServiceFactory(http: Http, options: RequestOptions) {
+        return new AuthHttp(new AuthConfig(), http, options);
+    }
 
     @NgModule({
         // ...
         imports: [
             // ...
+            HttpModule, // needed by AuthHttp
             MessagingModule.forRoot()
+        ],
+        providers: [
+            { provide: AuthHttp, useFactory: authHttpServiceFactory, deps: [Http, RequestOptions] }
         ]
     })
 
@@ -65,3 +77,33 @@ After the commit and tag is pushed Travis will automatically deploy the tagged v
 ### Gotchas
 
 When adding or using a new Angular dependency it must be added in the rollup configuration in the `build.js` so that it's not included in the output bundle.
+
+### Adding a peer library 
+
+Several locations (potentially) need to be touched when adding a peer library that should be provided by the application making use of this component.
+
+Adding `angular2-jwt` for example resulted in the following adjustments:
+```
+integration/src/systemjs.config.js
+  System.config.map: added 'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js'
+integration/package.json
+  dependencies: added "angular2-jwt": "^0.2.3"
+integration/yarn.lock <-- automatically added through yarn install
+integration/build.js
+  rollupBaseConfig.plugins.commonjs: added  include: ['node_modules/angular2-jwt/angular2-jwt.js']
+  
+karma-test-shim.js
+  System.config.map: added 'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js'
+karma.conf.js 
+  config.set.files: added { pattern: 'node_modules/angular2-jwt/**/*.js', included: false, watched: false }
+package.json
+  peerDependencies: added "angular2-jwt": "^0.2.3"
+  devDependencies: added "angular2-jwt": "^0.2.3"
+yarn.lock <-- automatically added through yarn install
+build.js
+  rollupBaseConfig.globals: added 'angular2-jwt': 'angular2-jwt'
+  rollupBaseConfig.external: added 'angular2-jwt'
+  
+src/demo/systemjs.config.js
+  System.config.map: added 'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js'
+```

--- a/build.js
+++ b/build.js
@@ -64,7 +64,8 @@ return Promise.resolve()
         '@angular/common': 'ng.common',
         '@angular/forms': 'ng.forms',
         '@angular/http': 'ng.http',
-        '@testeditor/messaging-service': 'te.messagingService'
+        '@testeditor/messaging-service': 'te.messagingService',
+        'angular2-jwt': 'angular2-jwt'
       },
       external: [
         // List of dependencies
@@ -73,6 +74,7 @@ return Promise.resolve()
         '@angular/common',
         '@angular/forms',
         '@angular/http',
+        'angular2-jwt',
         'rxjs/add/operator/toPromise',
         '@testeditor/messaging-service'
       ],

--- a/integration/build.js
+++ b/integration/build.js
@@ -24,7 +24,7 @@ const rollupConfig = {
   plugins: [
     nodeResolve({ jsnext: true, module: true }),
     commonjs({
-      include: ['node_modules/rxjs/**']
+      include: ['node_modules/rxjs/**', 'node_modules/angular2-jwt/angular2-jwt.js']
     }),
     uglify()
   ]

--- a/integration/package.json
+++ b/integration/package.json
@@ -40,7 +40,6 @@
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",
     "rxjs": "5.0.1",
-    "angular2-jwt": "^0.2.3",
     "systemjs": "0.19.40",
     "zone.js": "^0.8.4"
   },

--- a/integration/package.json
+++ b/integration/package.json
@@ -40,6 +40,7 @@
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",
     "rxjs": "5.0.1",
+    "angular2-jwt": "^0.2.3",
     "systemjs": "0.19.40",
     "zone.js": "^0.8.4"
   },

--- a/integration/package.json
+++ b/integration/package.json
@@ -18,7 +18,7 @@
     "e2e": "concurrently \"npm run serve:e2e\" \"npm run protractor\" --kill-others --success first",
     "pree2e:aot": "npm run build:e2e && npm run build:aot",
     "e2e:aot": "concurrently \"npm run serve:e2e-aot\" \"npm run protractor\" --kill-others --success first",
-    "preprotractor": "webdriver-manager update --gecko false",
+    "preprotractor": "webdriver-manager update --gecko false --ignore_ssl",
     "protractor": "protractor protractor.config.js"
   },
   "keywords": [],

--- a/integration/package.json
+++ b/integration/package.json
@@ -35,6 +35,7 @@
     "@angular/platform-browser-dynamic": "^4.1.3",
     "@testeditor/messaging-service": "^1.0.0",
     "@testeditor/workspace-navigator": "../dist/",
+    "angular2-jwt": "^0.2.3",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",

--- a/integration/src/app/app.module.ts
+++ b/integration/src/app/app.module.ts
@@ -1,11 +1,18 @@
 import { NgModule } from '@angular/core';
-import { HttpModule } from '@angular/http';
+import { Http, RequestOptions, HttpModule } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { MessagingModule } from '@testeditor/messaging-service';
 import { PersistenceService, WorkspaceNavigatorModule } from '@testeditor/workspace-navigator';
 
 import { AppComponent }  from './app.component';
 import { PersistenceServiceMock } from './persistence.service.mock';
+
+import { AuthHttp, AuthConfig } from 'angular2-jwt';
+
+export function authHttpServiceFactory(http: Http, options: RequestOptions) {
+  return new AuthHttp(new AuthConfig(), http, options);
+}
+
 
 @NgModule({
   imports: [
@@ -20,7 +27,8 @@ import { PersistenceServiceMock } from './persistence.service.mock';
   declarations: [ AppComponent ],
   bootstrap: [ AppComponent ],
   providers: [
-    { provide: PersistenceService, useClass: PersistenceServiceMock }
+    { provide: PersistenceService, useClass: PersistenceServiceMock },
+    { provide: AuthHttp, useFactory: authHttpServiceFactory, deps: [Http, RequestOptions] }
   ]
 })
 export class AppModule { }

--- a/integration/src/app/app.module.ts
+++ b/integration/src/app/app.module.ts
@@ -20,8 +20,7 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
     HttpModule,
     MessagingModule.forRoot(),
     WorkspaceNavigatorModule.forRoot({
-      serviceUrl: "http://localhost:9080",
-      authorizationHeader: "admin:admin@example.com"
+      persistenceServiceUrl: "http://localhost:9080",
     })
   ],
   declarations: [ AppComponent ],

--- a/integration/src/systemjs.config.js
+++ b/integration/src/systemjs.config.js
@@ -25,6 +25,7 @@
 
       // other libraries
       'rxjs':                      'npm:rxjs',
+      'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js',
       '@testeditor/messaging-service': 'npm:@testeditor/messaging-service/bundles/messaging-service.umd.js',
       '@testeditor/workspace-navigator': 'npm:@testeditor/workspace-navigator/bundles/workspace-navigator.umd.js'

--- a/integration/yarn.lock
+++ b/integration/yarn.lock
@@ -64,6 +64,8 @@
 
 "@testeditor/workspace-navigator@../dist/":
   version "0.6.0"
+  dependencies:
+    angular2-jwt "^0.2.3"
 
 "@types/jasmine@2.5.36":
   version "2.5.36"
@@ -121,6 +123,10 @@ ajv@^4.9.1:
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+angular2-jwt@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/angular2-jwt/-/angular2-jwt-0.2.3.tgz#54efdda3ceedba85f6a37b165f22ac22b8adf021"
 
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"

--- a/integration/yarn.lock
+++ b/integration/yarn.lock
@@ -63,7 +63,7 @@
   resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.0.0.tgz#5003d9703dbedfda73d0838a9be274e82bb21c3f"
 
 "@testeditor/workspace-navigator@../dist/":
-  version "0.6.0"
+  version "0.10.0"
   dependencies:
     angular2-jwt "^0.2.3"
 

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -69,6 +69,7 @@ System.config({
     '@testeditor/messaging-service': 'npm:@testeditor/messaging-service/bundles/messaging-service.umd.js',
     'ts-mockito': 'npm:ts-mockito/lib/ts-mockito.js',
     'lodash': 'npm:lodash/lodash.js',
+    'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js',
 
     // Testing bundles
     '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,6 +46,9 @@ module.exports = function (config) {
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },
 
+      // angular2-jwt
+      { pattern: 'node_modules/angular2-jwt/**/*.js', included: false, watched: false },
+
       // Paths loaded via module imports:
       // Angular itself
       { pattern: 'node_modules/@angular/**/*.js', included: false, watched: false },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "@angular/core": ">=4.0.0 <5.0.0",
     "@angular/forms": ">=4.0.0 <5.0.0",
     "@angular/http": ">=4.0.0 <5.0.0",
-    "@testeditor/messaging-service": "^1.0.0"
+    "@testeditor/messaging-service": "^1.0.0",
+    "angular2-jwt": "^0.2.3"
   },
   "devDependencies": {
     "@angular/common": "~4.3.2",
@@ -65,7 +66,7 @@
     "@angular/http": "~4.3.2",
     "@angular/platform-browser": "~4.3.2",
     "@angular/platform-browser-dynamic": "~4.3.2",
-    "@testeditor/messaging-service": "^1.1.0",
+    "@testeditor/messaging-service": "^1.2.0",
     "@types/jasmine": "2.5.36",
     "@types/node": "^6.0.46",
     "bootstrap": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@testeditor/messaging-service": "^1.2.0",
     "@types/jasmine": "2.5.36",
     "@types/node": "^6.0.46",
+    "angular2-jwt": "^0.2.3",
     "bootstrap": "^3.3.7",
     "camelcase": "^4.0.0",
     "concurrently": "3.4.0",

--- a/src/demo/app/app.module.ts
+++ b/src/demo/app/app.module.ts
@@ -1,11 +1,16 @@
 import { NgModule } from '@angular/core';
-import { HttpModule } from '@angular/http';
+import { HttpModule, Http, RequestOptions } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { MessagingModule } from '@testeditor/messaging-service';
 import { PersistenceService, WorkspaceNavigatorModule } from '@testeditor/workspace-navigator';
+import { AuthHttp, AuthConfig } from 'angular2-jwt';
 
 import { AppComponent }  from './app.component';
 import { PersistenceServiceMock } from './persistence.service.mock';
+
+export function authHttpServiceFactory(http: Http, options: RequestOptions) {
+  return new AuthHttp(new AuthConfig(), http, options);
+}
 
 @NgModule({
   imports: [
@@ -20,7 +25,8 @@ import { PersistenceServiceMock } from './persistence.service.mock';
   declarations: [ AppComponent ],
   bootstrap: [ AppComponent ],
   providers: [
-    { provide: PersistenceService, useClass: PersistenceServiceMock }
+    { provide: PersistenceService, useClass: PersistenceServiceMock },
+    { provide: AuthHttp, useFactory: authHttpServiceFactory, deps: [Http, RequestOptions] }
   ]
 })
 export class AppModule { }

--- a/src/demo/app/app.module.ts
+++ b/src/demo/app/app.module.ts
@@ -18,8 +18,7 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
     HttpModule,
     MessagingModule.forRoot(),
     WorkspaceNavigatorModule.forRoot({
-      serviceUrl: "http://localhost:9080",
-      authorizationHeader: "admin:admin@example.com"
+      persistenceServiceUrl: "http://localhost:9080",
     })
   ],
   declarations: [ AppComponent ],

--- a/src/demo/systemjs.config.js
+++ b/src/demo/systemjs.config.js
@@ -26,6 +26,7 @@
       // other libraries
       '@testeditor/messaging-service': 'npm:@testeditor/messaging-service/bundles/messaging-service.umd.js',
       'rxjs': 'npm:rxjs',
+      'angular2-jwt': 'npm:angular2-jwt/angular2-jwt.js'
     },
     // packages tells the System loader how to load when no filename and/or no extension
     packages: {

--- a/src/lib/src/service/persistence/persistence.service.config.ts
+++ b/src/lib/src/service/persistence/persistence.service.config.ts
@@ -1,6 +1,5 @@
 export class PersistenceServiceConfig {
 
-  serviceUrl: string;
-  authorizationHeader: string;
+  persistenceServiceUrl: string;
 
 }

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, Response, RequestOptionsArgs } from '@angular/http';
+import { AuthHttp } from 'angular2-jwt';
 
 import { WorkspaceElement } from '../../common/workspace-element';
 import { PersistenceServiceConfig } from './persistence.service.config';
@@ -11,20 +12,14 @@ export class PersistenceService {
 
   private serviceUrl: string;
   private listFilesUrl: string;
-  private requestOptions: RequestOptionsArgs;
 
-  constructor(private http: Http, config: PersistenceServiceConfig) {
+  constructor(private http: AuthHttp, config: PersistenceServiceConfig) {
     this.serviceUrl = config.serviceUrl;
     this.listFilesUrl = `${config.serviceUrl}/workspace/list-files`;
-    this.requestOptions = {
-      headers: new Headers({
-        'Authorization': config.authorizationHeader
-      })
-    };
   }
 
   listFiles(): Promise<WorkspaceElement> {
-    return this.http.get(this.listFilesUrl, this.requestOptions).toPromise()
+    return this.http.get(this.listFilesUrl).toPromise()
       .then(response => response.json());
   }
 
@@ -32,7 +27,6 @@ export class PersistenceService {
   createDocument(path: string, type: string): Promise<Response> {
     let url = `${this.serviceUrl}/documents/${path}`;
     let requestOptions = {
-      headers: this.requestOptions.headers,
       params: { type: type }
     };
     return this.http.post(url, "", requestOptions).toPromise();
@@ -40,7 +34,7 @@ export class PersistenceService {
 
   deleteResource(path: string): Promise<Response> {
     let url = `${this.serviceUrl}/documents/${path}`;
-    return this.http.delete(url, this.requestOptions).toPromise();
+    return this.http.delete(url).toPromise();
   }
 
 }

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -14,8 +14,8 @@ export class PersistenceService {
   private listFilesUrl: string;
 
   constructor(private http: AuthHttp, config: PersistenceServiceConfig) {
-    this.serviceUrl = config.serviceUrl;
-    this.listFilesUrl = `${config.serviceUrl}/workspace/list-files`;
+    this.serviceUrl = config.persistenceServiceUrl;
+    this.listFilesUrl = `${config.persistenceServiceUrl}/workspace/list-files`;
   }
 
   listFiles(): Promise<WorkspaceElement> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,9 +58,9 @@
   dependencies:
     tsickle "^0.21.0"
 
-"@testeditor/messaging-service@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.1.0.tgz#452c475fcb4f42f310690b6726dc3e9dd79bd706"
+"@testeditor/messaging-service@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.2.0.tgz#c87f5264aef6b9859c3b6f410dc173d9afbd40ec"
 
 "@types/jasmine@2.5.36":
   version "2.5.36"

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,6 +116,10 @@ amdefine@>=0.0.4, amdefine@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+angular2-jwt@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/angular2-jwt/-/angular2-jwt-0.2.3.tgz#54efdda3ceedba85f6a37b165f22ac22b8adf021"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"


### PR DESCRIPTION
The semantical relevant change is located in src/lib/src/service/persistence/persistence.service.ts. The Http was replaced with AuthHttp, which in turn puts the json  web token into every request. The application using this component (workspace-navigator) has to make sure to provide the angular2-jwt library and configuration to retrieve the right token (look at demo for an example).

Most of the other changes are due to the fact that adding a library to this project is rather tedious.