### PR TITLE
Test execution notification

### DIFF
--- a/src/demo/app/test.execution.service.mock.ts
+++ b/src/demo/app/test.execution.service.mock.ts
@@ -6,6 +6,6 @@ import { Injectable } from '@angular/core';
 export class TestExecutionServiceMock {
   execute(path: string): Promise<Response> {
     console.log(`Received execute(path: '${path}')`);
-    return Promise.resolve(new Response(new ResponseOptions({ status: 200 })));
+    return Promise.resolve(new Response(new ResponseOptions({ status: 201 })));
   }
 }

--- a/src/lib/src/common/workspace-element.ts
+++ b/src/lib/src/common/workspace-element.ts
@@ -7,3 +7,12 @@ export class WorkspaceElement {
   type: string;
   children: WorkspaceElement[];
 }
+
+export function nameWithoutFileExtension(element: WorkspaceElement): string {
+  let delimiterIndex = element.name.lastIndexOf('.');
+  if (delimiterIndex >= 0) {
+    return element.name.substring(0, delimiterIndex);
+  } else {
+    return element.name;
+  }
+};

--- a/src/lib/src/component/navigation/navigation.component.css
+++ b/src/lib/src/component/navigation/navigation.component.css
@@ -7,6 +7,7 @@
   resize: horizontal;
   overflow: auto;
   user-select: none;
+  position: relative;
 }
 
 .noselect {
@@ -70,4 +71,10 @@ button {
   background:none!important;
   border:none;
   padding:0!important;
+}
+
+.sidenav .alert-info {
+  position: absolute;
+  bottom: 0;
+  width: inherit;
 }

--- a/src/lib/src/component/navigation/navigation.component.html
+++ b/src/lib/src/component/navigation/navigation.component.html
@@ -13,5 +13,6 @@
     </div>
     <nav-tree-viewer [model]="workspace.root" [uiState]="uiState"></nav-tree-viewer>
   </div>
-  <div *ngIf="errorMessage" class="alert alert-danger">{{errorMessage}}</div>
+  <div *ngIf="errorMessage" id="errorMessage" class="alert alert-danger">{{errorMessage}}</div>
+  <div *ngIf="notification" id="notification" class="alert alert-info">{{notification}}</div>
 </div>

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -20,7 +20,7 @@ import { UiState } from '../ui-state';
 
 import * as events from '../event-types';
 import { ElementState } from '../../common/element-state';
-import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService }
+import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService, setTestExecutionServiceResponse, HTTP_STATUS_CREATED, HTTP_STATUS_ERROR }
     from './navigation.component.test.setup';
 
 describe('NavigationComponent', () => {
@@ -65,6 +65,7 @@ describe('NavigationComponent', () => {
     messagingService = TestBed.get(MessagingService);
     fixture.detectChanges();
     sidenav = fixture.debugElement.query(By.css('.sidenav'));
+    setTestExecutionServiceResponse(executionService, HTTP_STATUS_CREATED​​);
   });
 
   it('should be created', () => {
@@ -421,6 +422,32 @@ describe('NavigationComponent', () => {
     expect(notify).toBeFalsy();
     expect(component.notification).toBeFalsy();
 
+  }));
+
+  it('displays error message when test execution could not be started', fakeAsync(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = tclFile;
+    fixture.detectChanges();
+    let runIcon = sidenav.query(By.css('#run'));
+    setTestExecutionServiceResponse(executionService, HTTP_STATUS_ERROR​​);
+
+    // when
+    runIcon.nativeElement.click();
+    tick();
+
+    // then
+    fixture.detectChanges();
+    let notify = fixture.debugElement.query(By.css('#notification'));
+    expect(notify).toBeFalsy();
+
+    expect(component.errorMessage).toBeTruthy();
+    let alert = fixture.debugElement.query(By.css('#errorMessage'));
+    expect(alert).toBeTruthy();
+    expect(component.errorMessage).toEqual(`The test ${tclFile.name} could not be started.`);
+    expect(alert.nativeElement.innerText).toEqual(component.errorMessage);
+
+    tick(4000);
   }));
 
 });

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -22,6 +22,7 @@ import * as events from '../event-types';
 import { ElementState } from '../../common/element-state';
 import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService, setTestExecutionServiceResponse, HTTP_STATUS_CREATED, HTTP_STATUS_ERROR }
     from './navigation.component.test.setup';
+import { flush } from '@angular/core/testing';
 
 describe('NavigationComponent', () => {
 
@@ -337,7 +338,7 @@ describe('NavigationComponent', () => {
 
     // when
     runIcon.nativeElement.click();
-    tick(4000);
+    tick(NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
 
     // then
     verify(executionService.execute(tclFile.path)).once();
@@ -400,10 +401,10 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
     let notify = fixture.debugElement.query(By.css('#notification'));
     expect(notify).toBeTruthy();
-    expect(component.notification).toEqual(`Execution of ${tclFile.name} has been started.`);
+    expect(component.notification).toEqual(`Execution of "file" has been started.`);
     expect(notify.nativeElement.innerText).toEqual(component.notification);
 
-    tick(4000);
+    flush();
   }));
 
   it('removes notification sometime after test execution has been started', fakeAsync(() => {
@@ -415,7 +416,7 @@ describe('NavigationComponent', () => {
 
     // when
     runIcon.nativeElement.click();
-    tick(4000);
+    tick(NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
 
     // then
     let notify = fixture.debugElement.query(By.css('#notification'));
@@ -444,10 +445,10 @@ describe('NavigationComponent', () => {
     expect(component.errorMessage).toBeTruthy();
     let alert = fixture.debugElement.query(By.css('#errorMessage'));
     expect(alert).toBeTruthy();
-    expect(component.errorMessage).toEqual(`The test ${tclFile.name} could not be started.`);
+    expect(component.errorMessage).toEqual(`The test "file" could not be started.`);
     expect(alert.nativeElement.innerText).toEqual(component.errorMessage);
 
-    tick(4000);
+    flush();
   }));
 
 });

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule, Response, ResponseOptions } from '@angular/http';
@@ -20,7 +20,8 @@ import { UiState } from '../ui-state';
 
 import * as events from '../event-types';
 import { ElementState } from '../../common/element-state';
-import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService } from './navigation.component.test.setup';
+import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService }
+    from './navigation.component.test.setup';
 
 describe('NavigationComponent', () => {
 
@@ -37,7 +38,7 @@ describe('NavigationComponent', () => {
   beforeEach(async(() => {
     persistenceService = mockedPersistenceService();
     executionService = mockedTestExecutionService();
-2
+
     TestBed.configureTestingModule({
       declarations: [
         NavigationComponent,
@@ -93,7 +94,7 @@ describe('NavigationComponent', () => {
     fixture.whenStable().then(() => {
       fixture.detectChanges();
       expect(component.errorMessage).toBeTruthy();
-      let alert = fixture.debugElement.query(By.css(".alert"));
+      let alert = fixture.debugElement.query(By.css("#errorMessage"));
       expect(alert).toBeTruthy();
       expect(alert.nativeElement.innerText).toEqual(component.errorMessage);
     });
@@ -325,7 +326,7 @@ describe('NavigationComponent', () => {
     });
   }));
 
-  it('invokes test execution for currently selected test file when "run" button is clicked', async(() => {
+  it('invokes test execution for currently selected test file when "run" button is clicked', fakeAsync(() => {
     // given
     setupWorkspace(component, fixture);
     component.uiState.selectedElement = tclFile;
@@ -335,12 +336,11 @@ describe('NavigationComponent', () => {
 
     // when
     runIcon.nativeElement.click();
+    tick(4000);
 
     // then
-    fixture.whenStable().then(() => {
-      verify(executionService.execute(tclFile.path)).once();
-      expect(tclFile.state).toEqual(ElementState.Running);
-    });
+    verify(executionService.execute(tclFile.path)).once();
+    expect(tclFile.state).toEqual(ElementState.Running);
   }));
 
   it('disables the run button when selecting a non-executable file', async(() => {
@@ -382,6 +382,45 @@ describe('NavigationComponent', () => {
 
     // then
     expect(runIcon.properties['disabled']).toBeFalsy;
+  }));
+
+  it('displays notification when test execution has been started', fakeAsync(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = tclFile;
+    fixture.detectChanges();
+    let runIcon = sidenav.query(By.css('#run'));
+
+    // when
+    runIcon.nativeElement.click();
+    tick();
+
+    // then
+    fixture.detectChanges();
+    let notify = fixture.debugElement.query(By.css('#notification'));
+    expect(notify).toBeTruthy();
+    expect(component.notification).toEqual(`Execution of ${tclFile.name} has been started.`);
+    expect(notify.nativeElement.innerText).toEqual(component.notification);
+
+    tick(4000);
+  }));
+
+  it('removes notification sometime after test execution has been started', fakeAsync(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = tclFile;
+    fixture.detectChanges();
+    let runIcon = sidenav.query(By.css('#run'));
+
+    // when
+    runIcon.nativeElement.click();
+    tick(4000);
+
+    // then
+    let notify = fixture.debugElement.query(By.css('#notification'));
+    expect(notify).toBeFalsy();
+    expect(component.notification).toBeFalsy();
+
   }));
 
 });

--- a/src/lib/src/component/navigation/navigation.component.test.setup.ts
+++ b/src/lib/src/component/navigation/navigation.component.test.setup.ts
@@ -10,6 +10,9 @@ import { PersistenceService } from '../../service/persistence/persistence.servic
 import { TestExecutionService } from '../../service/execution/test.execution.service';
 import { Response, ResponseOptions } from '@angular/http';
 
+export const HTTP_STATUS_CREATED = 201;
+export const HTTP_STATUS_ERROR = 500;
+
 export const tclFile: WorkspaceElement = {
   name: "file.tcl",
   path: "path/to/file.tcl",
@@ -32,9 +35,13 @@ export function mockedPersistenceService() {
 
 export function mockedTestExecutionService() {
   const executionService = mock(TestExecutionService)
-  const response = new Response(new ResponseOptions({status: 200}));
-  when(executionService.execute(tclFile.path)).thenReturn(Promise.resolve(response));
+  setTestExecutionServiceResponse(executionService, HTTP_STATUS_CREATED​​);
   return executionService;
+}
+
+export function setTestExecutionServiceResponse(service: TestExecutionService, statusCode: number) {
+  const response = new Response(new ResponseOptions({status: statusCode}));
+  when(service.execute(tclFile.path)).thenReturn(Promise.resolve(response));
 }
 
 export function setupWorkspace(component: NavigationComponent, fixture: ComponentFixture<NavigationComponent>) {

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { PersistenceService } from '../../service/persistence/persistence.service';
 import { MessagingService } from '@testeditor/messaging-service';
 import { ElementType } from '../../common/element-type';
-import { WorkspaceElement } from '../../common/workspace-element';
+import { WorkspaceElement, nameWithoutFileExtension } from '../../common/workspace-element';
 import { Workspace } from '../../common/workspace';
 import { UiState } from '../ui-state';
 import * as events from '../event-types';
@@ -17,7 +17,8 @@ import { ElementState } from '../../common/element-state';
 })
 
 export class NavigationComponent implements OnInit {
-  readonly HTTP_STATUS_CREATED = 201;
+  static readonly HTTP_STATUS_CREATED = 201;
+  static readonly NOTIFICATION_TIMEOUT_MILLIS = 4000;
 
   workspace: Workspace;
   uiState: UiState;
@@ -118,17 +119,17 @@ export class NavigationComponent implements OnInit {
   run(): void {
     let selectedElement = this.uiState.selectedElement;
     this.executionService.execute(selectedElement.path).then(response => {
-        if (response.status === this.HTTP_STATUS_CREATED) {
+        if (response.status === NavigationComponent.HTTP_STATUS_CREATED) {
           selectedElement.state = ElementState.Running;
-          this.notification = `Execution of ${selectedElement.name} has been started.`;
+          this.notification = `Execution of "${nameWithoutFileExtension(selectedElement)}" has been started.`;
           setTimeout(() => {
             this.notification = null;
-          }, 4000);
+          }, NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
         } else {
-          this.errorMessage = `The test ${selectedElement.name} could not be started.`;
+          this.errorMessage = `The test "${nameWithoutFileExtension(selectedElement)}" could not be started.`;
           setTimeout(() => {
             this.errorMessage = null;
-          }, 4000);
+          }, NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
         }
       });
   }

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -21,6 +21,7 @@ export class NavigationComponent implements OnInit {
   workspace: Workspace;
   uiState: UiState;
   errorMessage: string;
+  notification: string;
 
   constructor(
     private messagingService: MessagingService,
@@ -114,9 +115,14 @@ export class NavigationComponent implements OnInit {
   }
 
   run(): void {
-    this.executionService.execute(this.uiState.selectedElement.path).then(response => {
+    let selectedElement = this.uiState.selectedElement;
+    this.executionService.execute(selectedElement.path).then(response => {
         if (response.status === 200) {
-          this.uiState.selectedElement.state = ElementState.Running;
+          selectedElement.state = ElementState.Running;
+          this.notification = `Execution of ${selectedElement.name} has been started.`;
+          setTimeout(() => {
+            this.notification = null;
+          }, 4000);
         }
       });
   }

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -17,6 +17,7 @@ import { ElementState } from '../../common/element-state';
 })
 
 export class NavigationComponent implements OnInit {
+  readonly HTTP_STATUS_CREATED = 201;
 
   workspace: Workspace;
   uiState: UiState;
@@ -117,11 +118,16 @@ export class NavigationComponent implements OnInit {
   run(): void {
     let selectedElement = this.uiState.selectedElement;
     this.executionService.execute(selectedElement.path).then(response => {
-        if (response.status === 200) {
+        if (response.status === this.HTTP_STATUS_CREATED) {
           selectedElement.state = ElementState.Running;
           this.notification = `Execution of ${selectedElement.name} has been started.`;
           setTimeout(() => {
             this.notification = null;
+          }, 4000);
+        } else {
+          this.errorMessage = `The test ${selectedElement.name} could not be started.`;
+          setTimeout(() => {
+            this.errorMessage = null;
           }, 4000);
         }
       });

--- a/src/lib/src/service/execution/test.execution.service.spec.ts
+++ b/src/lib/src/service/execution/test.execution.service.spec.ts
@@ -8,6 +8,7 @@ import { Injector, ReflectiveInjector } from '@angular/core';
 import { inject } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { fakeAsync } from '@angular/core/testing';
+import { HTTP_STATUS_CREATED } from '../../component/navigation/navigation.component.test.setup';
 
 describe('TestExecutionService', () => {
   let serviceConfig: TestExecutionServiceConfig;
@@ -38,7 +39,7 @@ describe('TestExecutionService', () => {
         expect(connection.request.method).toBe(RequestMethod.Post);
         expect(connection.request.url).toBe(serviceConfig.testExecutionServiceUrl + '?resource=' + tclFilePath);
 
-        connection.mockRespond(new Response( new ResponseOptions({status: 200})));
+        connection.mockRespond(new Response( new ResponseOptions({status: HTTP_STATUS_CREATED})));
       }
     );
 
@@ -47,7 +48,7 @@ describe('TestExecutionService', () => {
 
     // then
     .then(response => {
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(HTTP_STATUS_CREATED);
     });
   })));
 


### PR DESCRIPTION
Displays a notification on receiving the server response that a request to start executing a test was successful. The notification disappears after 4 sec. 

Also, the client now expects a response with status code `201` (`CREATED`; previously was: `200 OK`), in correspondence to what the persistence service actually delivers. If the response has a different status code, an error message is shown instead of the notification.