### PR TITLE
Feature/test execution focus

### DIFF
--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -369,9 +369,28 @@ describe('NavigationComponent', () => {
     let runIcon = sidenav.query(By.css('#run'));
 
     // when
-    component.selectElement(nonExecutableFile.path)
+    component.selectElement(nonExecutableFile.path);
 
     // then
+    fixture.whenStable().then(() => {
+      expect(runIcon.properties['disabled']).toBeTruthy();
+    });
+  }));
+
+  it('disables the run button when selecting a non-executable file while an executable file remains active', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    let runIcon = sidenav.query(By.css('#run'));
+    component.uiState.selectedElement = null;
+    component.uiState.activeEditorPath = tclFile.path;
+    fixture.detectChanges();
+    expect(runIcon.properties['disabled']).toBeFalsy();
+
+    // when
+    component.selectElement(nonExecutableFile.path);
+
+    // then
+    fixture.detectChanges();
     fixture.whenStable().then(() => {
       expect(runIcon.properties['disabled']).toBeTruthy();
     });

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -355,7 +355,7 @@ describe('NavigationComponent', () => {
 
     // then
     fixture.whenStable().then(() => {
-      expect(runIcon.properties['disabled']).toBeTruthy;
+      expect(runIcon.properties['disabled']).toBeTruthy();
     });
   }));
 
@@ -367,11 +367,12 @@ describe('NavigationComponent', () => {
     let runIcon = sidenav.query(By.css('#run'));
 
     // when
-    component.selectElement(tclFile.path)
+    component.selectElement(tclFile.path);
+    fixture.detectChanges();
 
     // then
     fixture.whenStable().then(() => {
-      expect(runIcon.properties['disabled']).toBeFalsy;
+      expect(runIcon.properties['disabled']).toBeFalsy();
     });
   }));
 
@@ -383,7 +384,7 @@ describe('NavigationComponent', () => {
     // when
 
     // then
-    expect(runIcon.properties['disabled']).toBeFalsy;
+    expect(runIcon.properties['disabled']).toBeTruthy();
   }));
 
   it('displays notification when test execution has been started', fakeAsync(() => {

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -345,6 +345,24 @@ describe('NavigationComponent', () => {
     expect(tclFile.state).toEqual(ElementState.Running);
   }));
 
+  it('invokes test execution for currently active test file when "run" button is clicked and no file is selected', fakeAsync(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = null;
+    component.uiState.activeEditorPath = tclFile.path;
+    fixture.detectChanges();
+    let runIcon = sidenav.query(By.css('#run'));
+    resetCalls(executionService);
+
+    // when
+    runIcon.nativeElement.click();
+    tick(NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
+
+    // then
+    verify(executionService.execute(tclFile.path)).once();
+    expect(tclFile.state).toEqual(ElementState.Running);
+  }));
+
   it('disables the run button when selecting a non-executable file', async(() => {
     // given
     setupWorkspace(component, fixture);
@@ -382,6 +400,32 @@ describe('NavigationComponent', () => {
     let runIcon = sidenav.query(By.css('#run'));
 
     // when
+
+    // then
+    expect(runIcon.properties['disabled']).toBeTruthy();
+  }));
+
+  it('keeps run button enabled when navigation pane looses focus', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    let runIcon = sidenav.query(By.css('#run'));
+    component.uiState.selectedElement = tclFile;
+
+    // when
+    messagingService.publish(events.EDITOR_ACTIVE, { path: tclFile.path });
+
+    // then
+    expect(runIcon.properties['disabled']).toBeFalsy();
+  }));
+
+  it('disables run button when non-executable file becomes active', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    let runIcon = sidenav.query(By.css('#run'));
+    component.uiState.selectedElement = tclFile;
+
+    // when
+    messagingService.publish(events.EDITOR_ACTIVE, { path: nonExecutableFile.path });
 
     // then
     expect(runIcon.properties['disabled']).toBeTruthy();

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -117,16 +117,20 @@ export class NavigationComponent implements OnInit {
   }
 
   run(): void {
-    let selectedElement = this.uiState.selectedElement;
-    this.executionService.execute(selectedElement.path).then(response => {
+    let elementToBeExecuted = this.uiState.selectedElement;
+    if (elementToBeExecuted == null) {
+      elementToBeExecuted = this.workspace.getElement(this.uiState.activeEditorPath);
+    }
+
+    this.executionService.execute(elementToBeExecuted.path).then(response => {
         if (response.status === NavigationComponent.HTTP_STATUS_CREATED) {
-          selectedElement.state = ElementState.Running;
-          this.notification = `Execution of "${nameWithoutFileExtension(selectedElement)}" has been started.`;
+          elementToBeExecuted.state = ElementState.Running;
+          this.notification = `Execution of "${nameWithoutFileExtension(elementToBeExecuted)}" has been started.`;
           setTimeout(() => {
             this.notification = null;
           }, NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
         } else {
-          this.errorMessage = `The test "${nameWithoutFileExtension(selectedElement)}" could not be started.`;
+          this.errorMessage = `The test "${nameWithoutFileExtension(elementToBeExecuted)}" could not be started.`;
           setTimeout(() => {
             this.errorMessage = null;
           }, NavigationComponent.NOTIFICATION_TIMEOUT_MILLIS);
@@ -151,7 +155,8 @@ export class NavigationComponent implements OnInit {
   }
 
   selectionIsExecutable(): boolean {
-    return this.uiState.selectedElement != null && this.uiState.selectedElement.path.endsWith('.tcl');
+    return this.uiState.activeEditorPath != null && this.uiState.activeEditorPath.endsWith('.tcl') ||
+      this.uiState.selectedElement != null && this.uiState.selectedElement.path.endsWith('.tcl');
   }
 
 }

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -155,8 +155,8 @@ export class NavigationComponent implements OnInit {
   }
 
   selectionIsExecutable(): boolean {
-    return this.uiState.activeEditorPath != null && this.uiState.activeEditorPath.endsWith('.tcl') ||
-      this.uiState.selectedElement != null && this.uiState.selectedElement.path.endsWith('.tcl');
+    return this.uiState.selectedElement == null && this.uiState.activeEditorPath != null && this.uiState.activeEditorPath.endsWith('.tcl')
+        || this.uiState.selectedElement != null && this.uiState.selectedElement.path.endsWith('.tcl');
   }
 
 }

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -155,8 +155,8 @@ export class NavigationComponent implements OnInit {
   }
 
   selectionIsExecutable(): boolean {
-    return this.uiState.selectedElement == null && this.uiState.activeEditorPath != null && this.uiState.activeEditorPath.endsWith('.tcl')
-        || this.uiState.selectedElement != null && this.uiState.selectedElement.path.endsWith('.tcl');
+    return (this.uiState.selectedElement === null && this.uiState.activeEditorPath !== null && this.uiState.activeEditorPath.endsWith('.tcl'))
+        || (this.uiState.selectedElement !== null && this.uiState.selectedElement.path.endsWith('.tcl'));
   }
 
 }

--- a/src/lib/src/component/ui-state.ts
+++ b/src/lib/src/component/ui-state.ts
@@ -2,8 +2,8 @@ import { WorkspaceElement } from '../common/workspace-element';
 
 export class UiState {
 
-  activeEditorPath: string;
-  selectedElement: WorkspaceElement;
+  activeEditorPath: string = null;
+  selectedElement: WorkspaceElement = null;
 
   newElementRequest: { selectedElement: WorkspaceElement, type: string }
 


### PR DESCRIPTION
Run button is enabled _iff_
- there is a selection _and_ the selection is executable, _or_
- there is no selection, there is an active file, _and_ that file is executable.

In particular, this means the run button will **not** be enabled when a non-executable file is selected, but an executable file is active. (~Clicking into the editor / tab should set / keep the active state, but also remove the selection, in which case the button will be enabled again.~ That's probably not true, because the EDITOR_ACTIVE event is only sent when switching between tabs, not when an editor tab that remained in the foreground regains focus. This would have to be changed in [test-editor-web](https://github.com/test-editor/test-editor-web).)

The PR also contains fixes for some wrong test assumptions (https://github.com/test-editor/web-workspace-navigator/commit/0873dd32dc23415193eebe86b0ea4aba9e220131).
  