### PR TITLE
Feature/keyboard navigation

### DIFF
--- a/src/lib/src/common/workspace.spec.ts
+++ b/src/lib/src/common/workspace.spec.ts
@@ -132,7 +132,7 @@ describe('Workspace.getParent()', () => {
       });
 
 
-      it('returns undefined if the normalized path is empty', () => {
+      it('returns undefined for parent of empty path', () => {
         // given
         let workspace = createWorkspaceWithRootFolder('/');
         // when

--- a/src/lib/src/common/workspace.spec.ts
+++ b/src/lib/src/common/workspace.spec.ts
@@ -12,6 +12,38 @@ function createWorkspaceWithRootFolder(path: string): Workspace {
   return new Workspace(element);
 }
 
+const firstChild: WorkspaceElement = {
+  name: 'firstChild',
+  path: 'root/firstChild',
+  type: ElementType.File,
+  children: []
+};
+const grandChild: WorkspaceElement = {
+  name: 'grandChild',
+  path: 'root/middleChild/grandChild',
+  type: ElementType.File,
+  children: []
+};
+const middleChild: WorkspaceElement = {
+  name: 'middleChild',
+  path: 'root/middleChild',
+  type: ElementType.Folder,
+  children: [grandChild]
+};
+const lastChild: WorkspaceElement = {
+  name: 'lastChild',
+  path: 'root/lastChild',
+  type: ElementType.File,
+  children: []
+};
+const workspaceWithSubElements = new Workspace({
+  name: 'folder',
+  path: 'root',
+  type: ElementType.Folder,
+  children: [firstChild, middleChild, lastChild]
+});
+
+
 describe('Workspace', () => {
 
   it('can retrieve root element', () => {
@@ -76,3 +108,52 @@ describe('Workspace.getSubpaths()', () => {
   });
 
 });
+
+
+
+describe('Workspace.getParent()', () => {
+
+      it('returns the parent element', () => {
+        // given
+        let path = grandChild.path;
+        // when
+        let actualParent = workspaceWithSubElements.getParent(path);
+        // then
+        expect(actualParent).toEqual(middleChild);
+      });
+
+      it('returns undefined for the root element', () => {
+        // given
+        let path = workspaceWithSubElements.root.path;
+        // when
+        let actualParent = workspaceWithSubElements.getParent(path);
+        // then
+        expect(actualParent).toBeUndefined();
+      });
+
+
+      it('returns undefined if the normalized path is empty', () => {
+        // given
+        let workspace = createWorkspaceWithRootFolder('/');
+        // when
+        let actualParent = workspace.getParent('');
+        // then
+        expect(actualParent).toBeUndefined();
+      });
+
+      it('returns root, if root´s normalized path is the empty string, for a path not containing any slashes', () => {
+        // given
+        let workspace = createWorkspaceWithRootFolder('/');
+        workspace.root.children.push({
+          name: 'firstChild',
+          path: 'firstChild',
+          type: ElementType.File,
+          children: []
+        });
+        // when
+        let actualParent = workspace.getParent('firstChild');
+        // then
+        expect(actualParent).toEqual(workspace.root);
+      });
+
+    });

--- a/src/lib/src/common/workspace.ts
+++ b/src/lib/src/common/workspace.ts
@@ -50,4 +50,16 @@ export class Workspace {
     return this.pathToElement.get(normalized);
   }
 
+  getParent(path: string): WorkspaceElement | undefined {
+    let normalized = this.normalizePath(path);
+    if (normalized !== '') {
+      let lastSeparatorIndex = normalized.lastIndexOf('/');
+      if (lastSeparatorIndex >= 0) {
+        let parentPath = normalized.substring(0, lastSeparatorIndex);
+        return this.getElement(parentPath);
+      } else if (this.normalizePath(this.root.path) === '') {
+        return this.root;
+      }
+    }
+  }
 }

--- a/src/lib/src/component/navigation/navigation.component.html
+++ b/src/lib/src/component/navigation/navigation.component.html
@@ -11,7 +11,7 @@
         <button id="collapse-all" class="icon fa fa-minus-square-o" aria-hidden="true" (click)="collapseAll()" title="collapse all"></button>
       </div>
     </div>
-    <nav-tree-viewer [model]="workspace.root" [uiState]="uiState"></nav-tree-viewer>
+    <nav-tree-viewer tabindex="0" [model]="workspace.root" [uiState]="uiState" (keyup)="onKeyUp($event)"></nav-tree-viewer>
   </div>
   <div *ngIf="errorMessage" id="errorMessage" class="alert alert-danger">{{errorMessage}}</div>
   <div *ngIf="notification" id="notification" class="alert alert-info">{{notification}}</div>

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -28,6 +28,11 @@ describe('NavigationComponent', () => {
 
   const examplePath = "some/path.txt";
 
+  const KEY_RIGHT = 'ArrowRight';
+  const KEY_LEFT = 'ArrowLeft';
+  const KEY_UP = 'ArrowUp';
+  const KEY_DOWN = 'ArrowDown';
+
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
   let persistenceService: PersistenceService;
@@ -514,5 +519,191 @@ describe('NavigationComponent', () => {
 
     flush();
   }));
+
+
+  it('sets expanded state when right arrow key is pressed', () => {
+    // given
+    setupWorkspace(component, fixture);
+    let element = component.workspace.getElement('subfolder');
+    component.uiState.selectedElement = element;
+    component.uiState.setExpanded(element.path, false);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_RIGHT});
+
+    // then
+    let expandedState = component.uiState.isExpanded(element.path);
+    expect(expandedState).toBeTruthy();
+  });
+
+  it('keeps expanded state when right arrow key is pressed', () => {
+    // given
+    setupWorkspace(component, fixture);
+    let element = component.workspace.getElement('subfolder');
+    component.uiState.selectedElement = element;
+    component.uiState.setExpanded(element.path, true);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_RIGHT});
+
+    // then
+    let expandedState = component.uiState.isExpanded(element.path);
+    expect(expandedState).toBeTruthy();
+  });
+
+  it('sets collapsed state when left arrow key is pressed', () => {
+    // given
+    setupWorkspace(component, fixture);
+    let element = component.workspace.getElement('subfolder');
+    component.uiState.selectedElement = element;
+    component.uiState.setExpanded(element.path, true);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_LEFT});
+
+    // then
+    let expandedState = component.uiState.isExpanded(element.path);
+    expect(expandedState).toBeFalsy();
+  });
+
+  it('keeps collapsed state when left arrow key is pressed', () => {
+    // given
+    setupWorkspace(component, fixture);
+    let element = component.workspace.getElement('subfolder');
+    component.uiState.selectedElement = element;
+    component.uiState.setExpanded(element.path, false);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_LEFT});
+
+    // then
+    let expandedState = component.uiState.isExpanded(element.path);
+    expect(expandedState).toBeFalsy();
+  });
+
+  it('selects the next sibling element when the down arrow key is pressed', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = nonExecutableFile;
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+
+    // then
+    expect(component.uiState.selectedElement).toEqual(tclFile);
+
+  }));
+
+  it('selects the first child element when the down arrow key is pressed', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = component.workspace.getElement('subfolder');
+    component.uiState.setExpanded(component.uiState.selectedElement.path, true);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+
+    // then
+    expect(component.uiState.selectedElement.name).toEqual('newFolder');
+
+  }));
+
+  it('selects the parent`s next sibling element when the down arrow key is pressed', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    component.uiState.selectedElement = component.workspace.getElement('subfolder/newFolder');
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+
+    // then
+    expect(component.uiState.selectedElement).toEqual(nonExecutableFile);
+
+  }));
+
+  it('leaves the selection unchanged when the down arrow key is pressed', async(() => {
+    // given
+    setupWorkspace(component, fixture);
+    let lastElement = component.workspace.getElement('subfolder/file.tcl');
+    component.uiState.selectedElement = lastElement;
+    component.uiState.setExpanded(lastElement.path, true);
+    fixture.detectChanges();
+
+    // when
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+
+    // then
+    expect(component.uiState.selectedElement).toEqual(lastElement);
+
+  }));
+
+
+it('selects the preceding sibling element when the up arrow key is pressed', async(() => {
+  // given
+  setupWorkspace(component, fixture);
+  component.uiState.selectedElement = tclFile;
+  fixture.detectChanges();
+
+  // when
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+
+  // then
+  expect(component.uiState.selectedElement).toEqual(nonExecutableFile);
+
+}));
+
+it('selects the parent element when the up arrow key is pressed', async(() => {
+  // given
+  setupWorkspace(component, fixture);
+  component.uiState.selectedElement = component.workspace.getElement('subfolder/newFolder');
+  component.uiState.setExpanded(component.uiState.selectedElement.path, true);
+  fixture.detectChanges();
+
+  // when
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+
+  // then
+  expect(component.uiState.selectedElement.name).toEqual('subfolder');
+
+}));
+
+it('selects the preceding sibling`s last child element when the up arrow key is pressed', async(() => {
+  // given
+  setupWorkspace(component, fixture);
+  component.uiState.selectedElement = nonExecutableFile;
+  component.uiState.setExpanded(component.uiState.selectedElement.path, true);
+  fixture.detectChanges();
+
+  // when
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+
+  // then
+  expect(component.uiState.selectedElement).toEqual(component.workspace.getElement('subfolder/newFolder'));
+
+}));
+
+it('leaves the selection unchanged when the up arrow key is pressed', async(() => {
+  // given
+  setupWorkspace(component, fixture);
+  let firstElement = component.workspace.root;
+  component.uiState.selectedElement = firstElement;
+  component.uiState.setExpanded(firstElement.path, true);
+  fixture.detectChanges();
+
+  // when
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+
+  // then
+  expect(component.uiState.selectedElement).toEqual(firstElement);
+
+}));
+
 
 });

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -20,7 +20,7 @@ import { UiState } from '../ui-state';
 
 import * as events from '../event-types';
 import { ElementState } from '../../common/element-state';
-import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService, setTestExecutionServiceResponse, HTTP_STATUS_CREATED, HTTP_STATUS_ERROR }
+import { nonExecutableFile, tclFile, setupWorkspace, mockedPersistenceService, mockedTestExecutionService, setTestExecutionServiceResponse, HTTP_STATUS_CREATED, HTTP_STATUS_ERROR, succeedingSiblingOfTclFile, lastElement }
     from './navigation.component.test.setup';
 import { flush } from '@angular/core/testing';
 
@@ -28,11 +28,11 @@ describe('NavigationComponent', () => {
 
   const examplePath = "some/path.txt";
 
-  const KEY_RIGHT = 'ArrowRight';
-  const KEY_LEFT = 'ArrowLeft';
-  const KEY_UP = 'ArrowUp';
-  const KEY_DOWN = 'ArrowDown';
-  const KEY_ENTER = 'Enter';
+  const KB_EXPAND_NODE = 'ArrowRight';
+  const KB_COLLAPSE_NODE = 'ArrowLeft';
+  const KB_NAVIGATE_PREVIOUS = 'ArrowUp';
+  const KB_NAVIGATE_NEXT = 'ArrowDown';
+  const KB_OPEN_FILE = 'Enter';
 
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
@@ -531,7 +531,7 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_RIGHT});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_EXPAND_NODE});
 
     // then
     let expandedState = component.uiState.isExpanded(element.path);
@@ -547,7 +547,7 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_RIGHT});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_EXPAND_NODE});
 
     // then
     let expandedState = component.uiState.isExpanded(element.path);
@@ -563,7 +563,7 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_LEFT});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_COLLAPSE_NODE});
 
     // then
     let expandedState = component.uiState.isExpanded(element.path);
@@ -579,7 +579,7 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_LEFT});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_COLLAPSE_NODE});
 
     // then
     let expandedState = component.uiState.isExpanded(element.path);
@@ -589,14 +589,14 @@ describe('NavigationComponent', () => {
   it('selects the next sibling element when the down arrow key is pressed', async(() => {
     // given
     setupWorkspace(component, fixture);
-    component.uiState.selectedElement = nonExecutableFile;
+    component.uiState.selectedElement = tclFile;
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_NEXT});
 
     // then
-    expect(component.uiState.selectedElement).toEqual(tclFile);
+    expect(component.uiState.selectedElement).toEqual(succeedingSiblingOfTclFile);
 
   }));
 
@@ -608,7 +608,7 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_NEXT});
 
     // then
     expect(component.uiState.selectedElement.name).toEqual('newFolder');
@@ -622,23 +622,22 @@ describe('NavigationComponent', () => {
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_NEXT});
 
     // then
     expect(component.uiState.selectedElement).toEqual(nonExecutableFile);
 
   }));
 
-  it('leaves the selection unchanged when the down arrow key is pressed', async(() => {
+  it('leaves the selection unchanged when the down arrow key is pressed on the last element', async(() => {
     // given
     setupWorkspace(component, fixture);
-    let lastElement = component.workspace.getElement('subfolder/file.tcl');
     component.uiState.selectedElement = lastElement;
     component.uiState.setExpanded(lastElement.path, true);
     fixture.detectChanges();
 
     // when
-    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_DOWN});
+    sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_NEXT});
 
     // then
     expect(component.uiState.selectedElement).toEqual(lastElement);
@@ -653,14 +652,14 @@ it('selects the preceding sibling element when the up arrow key is pressed', asy
   fixture.detectChanges();
 
   // when
-  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_PREVIOUS});
 
   // then
   expect(component.uiState.selectedElement).toEqual(nonExecutableFile);
 
 }));
 
-it('selects the parent element when the up arrow key is pressed', async(() => {
+it('selects the parent element when the up arrow key is pressed on the first child', async(() => {
   // given
   setupWorkspace(component, fixture);
   component.uiState.selectedElement = component.workspace.getElement('subfolder/newFolder');
@@ -668,7 +667,7 @@ it('selects the parent element when the up arrow key is pressed', async(() => {
   fixture.detectChanges();
 
   // when
-  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_PREVIOUS});
 
   // then
   expect(component.uiState.selectedElement.name).toEqual('subfolder');
@@ -683,14 +682,14 @@ it('selects the preceding sibling`s last child element when the up arrow key is 
   fixture.detectChanges();
 
   // when
-  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_PREVIOUS});
 
   // then
   expect(component.uiState.selectedElement).toEqual(component.workspace.getElement('subfolder/newFolder'));
 
 }));
 
-it('leaves the selection unchanged when the up arrow key is pressed', async(() => {
+it('leaves the selection unchanged when the up arrow key is pressed on the first element', async(() => {
   // given
   setupWorkspace(component, fixture);
   let firstElement = component.workspace.root;
@@ -699,7 +698,7 @@ it('leaves the selection unchanged when the up arrow key is pressed', async(() =
   fixture.detectChanges();
 
   // when
-  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_UP});
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_NAVIGATE_PREVIOUS});
 
   // then
   expect(component.uiState.selectedElement).toEqual(firstElement);
@@ -716,7 +715,7 @@ it('emits "navigation.open" message when the enter key is pressed', () => {
   messagingService.subscribe(events.NAVIGATION_OPEN, callback);
 
   // when
-  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_ENTER})
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KB_OPEN_FILE})
 
   // then
   expect(callback).toHaveBeenCalledTimes(1);

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -32,6 +32,7 @@ describe('NavigationComponent', () => {
   const KEY_LEFT = 'ArrowLeft';
   const KEY_UP = 'ArrowUp';
   const KEY_DOWN = 'ArrowDown';
+  const KEY_ENTER = 'Enter';
 
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
@@ -705,5 +706,24 @@ it('leaves the selection unchanged when the up arrow key is pressed', async(() =
 
 }));
 
+it('emits "navigation.open" message when the enter key is pressed', () => {
+  // given
+  setupWorkspace(component, fixture);
+  component.uiState.setExpanded(component.workspace.getElement('subfolder').path, true);
+  component.uiState.selectedElement = tclFile;
+  fixture.detectChanges();
+  let callback = jasmine.createSpy('callback');
+  messagingService.subscribe(events.NAVIGATION_OPEN, callback);
+
+  // when
+  sidenav.query(By.css('nav-tree-viewer')).triggerEventHandler('keyup', { key: KEY_ENTER})
+
+  // then
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({
+    name: tclFile.name,
+    path: tclFile.path
+  }));
+});
 
 });

--- a/src/lib/src/component/navigation/navigation.component.test.setup.ts
+++ b/src/lib/src/component/navigation/navigation.component.test.setup.ts
@@ -15,14 +15,14 @@ export const HTTP_STATUS_ERROR = 500;
 
 export const tclFile: WorkspaceElement = {
   name: "file.tcl",
-  path: "path/to/file.tcl",
+  path: "subfolder/file.tcl",
   type: ElementType.File,
   children: []
 };
 
 export const nonExecutableFile: WorkspaceElement = {
   name: 'nonExecutable.txt',
-  path: 'path/to/nonExecutable.txt',
+  path: 'subfolder/nonExecutable.txt',
   type: ElementType.File,
   children: []
 };

--- a/src/lib/src/component/navigation/navigation.component.test.setup.ts
+++ b/src/lib/src/component/navigation/navigation.component.test.setup.ts
@@ -14,8 +14,8 @@ export const HTTP_STATUS_CREATED = 201;
 export const HTTP_STATUS_ERROR = 500;
 
 export const tclFile: WorkspaceElement = {
-  name: "file.tcl",
-  path: "subfolder/file.tcl",
+  name: 'file.tcl',
+  path: 'subfolder/file.tcl',
   type: ElementType.File,
   children: []
 };
@@ -23,6 +23,20 @@ export const tclFile: WorkspaceElement = {
 export const nonExecutableFile: WorkspaceElement = {
   name: 'nonExecutable.txt',
   path: 'subfolder/nonExecutable.txt',
+  type: ElementType.File,
+  children: []
+};
+
+export const succeedingSiblingOfTclFile: WorkspaceElement = {
+  name: 'siblingOf.file.tcl',
+  path: 'subfolder/siblingOf.file.tcl',
+  type: ElementType.File,
+  children: []
+};
+
+export const lastElement: WorkspaceElement = {
+  name: 'last.element',
+  path: 'subfolder/last.element',
   type: ElementType.File,
   children: []
 };
@@ -46,8 +60,8 @@ export function setTestExecutionServiceResponse(service: TestExecutionService, s
 
 export function setupWorkspace(component: NavigationComponent, fixture: ComponentFixture<NavigationComponent>) {
   const subfolder: WorkspaceElement = {
-    name: "subfolder",
-    path: "subfolder",
+    name: 'subfolder',
+    path: 'subfolder',
     type: ElementType.Folder,
     children: [
       {
@@ -57,12 +71,14 @@ export function setupWorkspace(component: NavigationComponent, fixture: Componen
         children: []
       },
       nonExecutableFile,
-      tclFile
+      tclFile,
+      succeedingSiblingOfTclFile,
+      lastElement
     ]
   };
   const root: WorkspaceElement = {
-    name: "root",
-    path: "",
+    name: 'root',
+    path: '',
     type: ElementType.Folder,
     children: [subfolder]
   };

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -185,7 +185,7 @@ export class NavigationComponent implements OnInit {
         break;
       }
       case this.KEY_DOWN: {
-        let successor = this.next(this.uiState.selectedElement);
+        let successor = this.nextVisible(this.uiState.selectedElement);
         if (successor != null) {
           this.uiState.selectedElement = successor;
           this.changeDetectorRef.detectChanges();
@@ -193,7 +193,7 @@ export class NavigationComponent implements OnInit {
         break;
       }
       case this.KEY_UP: {
-        let predecessor = this.previous(this.uiState.selectedElement);
+        let predecessor = this.previousVisible(this.uiState.selectedElement);
         if (predecessor != null) {
           this.uiState.selectedElement = predecessor;
           this.changeDetectorRef.detectChanges();
@@ -212,7 +212,7 @@ export class NavigationComponent implements OnInit {
     }
   }
 
-  private next(element: WorkspaceElement): WorkspaceElement {
+  private nextVisible(element: WorkspaceElement): WorkspaceElement {
     if (element.children.length > 0 && this.uiState.isExpanded(element.path)) {
       return element.children[0];
     }
@@ -232,7 +232,7 @@ export class NavigationComponent implements OnInit {
     return null;
   }
 
-  private previous(element: WorkspaceElement): WorkspaceElement {
+  private previousVisible(element: WorkspaceElement): WorkspaceElement {
     let parent = this.workspace.getParent(element.path);
     if (parent != null) {
       let elementIndex = parent.children.indexOf(element);

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -27,6 +27,7 @@ export class NavigationComponent implements OnInit {
   readonly KEY_LEFT = 'ArrowLeft';
   readonly KEY_UP = 'ArrowUp';
   readonly KEY_DOWN = 'ArrowDown';
+  readonly KEY_ENTER = 'Enter';
 
   workspace: Workspace;
   uiState: UiState;
@@ -172,13 +173,13 @@ export class NavigationComponent implements OnInit {
     let element = this.uiState.selectedElement;
     switch (event.key) {
       case this.KEY_RIGHT: {
-        if (element.type === ElementType.Folder) {
+        if (element !== null && element.type === ElementType.Folder) {
           this.uiState.setExpanded(element.path, true);
         }
         break;
       }
       case this.KEY_LEFT: {
-        if (element.type === ElementType.Folder) {
+        if (element !== null && element.type === ElementType.Folder) {
           this.uiState.setExpanded(element.path, false);
         }
         break;
@@ -197,6 +198,16 @@ export class NavigationComponent implements OnInit {
           this.uiState.selectedElement = predecessor;
           this.changeDetectorRef.detectChanges();
         }
+        break;
+      }
+      case this.KEY_ENTER: {
+        if (element !== null && element.type === ElementType.File) {
+          this.messagingService.publish(events.NAVIGATION_OPEN, {
+            name: element.name,
+            path: element.path
+          });
+        }
+        break;
       }
     }
   }

--- a/src/lib/src/component/navigation/navigation.component.ts
+++ b/src/lib/src/component/navigation/navigation.component.ts
@@ -20,6 +20,14 @@ export class NavigationComponent implements OnInit {
   static readonly HTTP_STATUS_CREATED = 201;
   static readonly NOTIFICATION_TIMEOUT_MILLIS = 4000;
 
+  /**
+   * See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+   */
+  readonly KEY_RIGHT = 'ArrowRight';
+  readonly KEY_LEFT = 'ArrowLeft';
+  readonly KEY_UP = 'ArrowUp';
+  readonly KEY_DOWN = 'ArrowDown';
+
   workspace: Workspace;
   uiState: UiState;
   errorMessage: string;
@@ -157,6 +165,77 @@ export class NavigationComponent implements OnInit {
   selectionIsExecutable(): boolean {
     return (this.uiState.selectedElement === null && this.uiState.activeEditorPath !== null && this.uiState.activeEditorPath.endsWith('.tcl'))
         || (this.uiState.selectedElement !== null && this.uiState.selectedElement.path.endsWith('.tcl'));
+  }
+
+  onKeyUp(event: KeyboardEvent) {
+    console.log('KeyUp event received:\n' + event);
+    let element = this.uiState.selectedElement;
+    switch (event.key) {
+      case this.KEY_RIGHT: {
+        if (element.type === ElementType.Folder) {
+          this.uiState.setExpanded(element.path, true);
+        }
+        break;
+      }
+      case this.KEY_LEFT: {
+        if (element.type === ElementType.Folder) {
+          this.uiState.setExpanded(element.path, false);
+        }
+        break;
+      }
+      case this.KEY_DOWN: {
+        let successor = this.next(this.uiState.selectedElement);
+        if (successor != null) {
+          this.uiState.selectedElement = successor;
+          this.changeDetectorRef.detectChanges();
+        }
+        break;
+      }
+      case this.KEY_UP: {
+        let predecessor = this.previous(this.uiState.selectedElement);
+        if (predecessor != null) {
+          this.uiState.selectedElement = predecessor;
+          this.changeDetectorRef.detectChanges();
+        }
+      }
+    }
+  }
+
+  private next(element: WorkspaceElement): WorkspaceElement {
+    if (element.children.length > 0 && this.uiState.isExpanded(element.path)) {
+      return element.children[0];
+    }
+
+    let parent = this.workspace.getParent(element.path);
+    while (parent != null) {
+      let elementIndex = parent.children.indexOf(element);
+      if (elementIndex + 1 < parent.children.length) { // implicitly assuming elementIndex > -1
+        return parent.children[elementIndex + 1];
+      }
+      // last element on this level: get parent's next sibling instead
+      element = parent;
+      parent = this.workspace.getParent(parent.path);
+    }
+
+    // element is last one overall / has no successor
+    return null;
+  }
+
+  private previous(element: WorkspaceElement): WorkspaceElement {
+    let parent = this.workspace.getParent(element.path);
+    if (parent != null) {
+      let elementIndex = parent.children.indexOf(element);
+      if (elementIndex === 0) {
+        return parent;
+      } else {
+        let predecessor = parent.children[elementIndex - 1];
+        while (predecessor.type === ElementType.Folder && this.uiState.isExpanded(predecessor.path)) {
+          predecessor = predecessor.children[predecessor.children.length - 1];
+        }
+        return predecessor;
+      }
+    }
+    return null;
   }
 
 }


### PR DESCRIPTION
Allow navigation with the arrow keys through the tree view:
- up/down selects element visible immediately above/below current selection,
- left/right collapses/expands selected folder-type tree nodes.

In addition, the enter key opens the currently selected file.



