### PR TITLE
refactor in favor of smaller classes / functions, more individual uni…

### DIFF
--- a/src/lib/src/common/key.actions.ts
+++ b/src/lib/src/common/key.actions.ts
@@ -1,0 +1,10 @@
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+ */
+export class KeyActions {
+  static readonly EXPAND_NODE = 'ArrowRight';
+  static readonly COLLAPSE_NODE = 'ArrowLeft';
+  static readonly NAVIGATE_PREVIOUS = 'ArrowUp';
+  static readonly NAVIGATE_NEXT = 'ArrowDown';
+  static readonly OPEN_FILE = 'Enter';
+}

--- a/src/lib/src/common/util/workspace.navigation.helper.spec.ts
+++ b/src/lib/src/common/util/workspace.navigation.helper.spec.ts
@@ -1,0 +1,185 @@
+import { WorkspaceNavigationHelper } from './workspace.navigation.helper';
+import { createWorkspaceWithSubElements, firstChild, middleChild, grandChild, lastChild, greatGrandChild } from '../workspace.spec.data';
+import { UiState } from '../../component/ui-state';
+import { worker } from 'cluster';
+
+describe('WorkspaceNavigationHelper', () => {
+
+  // given
+  const workspace = createWorkspaceWithSubElements();
+  let uiState: UiState​​ = null;
+  let helper: WorkspaceNavigationHelper = null;
+
+  beforeEach(() => {
+    uiState = new UiState();
+    helper = new WorkspaceNavigationHelper(workspace, uiState);
+    uiState.setExpanded(workspace.root.path, true);
+    uiState.setExpanded(middleChild.path, true);
+    uiState.setExpanded(grandChild.path, true);
+  });
+
+  describe('nextVisible()', () => {
+
+    it('returns the first child element', () => {
+      // when
+      let actualSuccessor = helper.nextVisible(workspace.root);
+
+      // then
+      expect(actualSuccessor).toEqual(firstChild);
+    });
+
+    it('returns the next sibling element', () => {
+      // when
+      let actualSuccessor = helper.nextVisible(firstChild);
+
+      // then
+      expect(actualSuccessor).toEqual(middleChild);
+    });
+
+    it('returns the parent`s next sibling element when collapsed', () => {
+      // given
+      uiState.setExpanded(grandChild.path, false);
+      // when
+      let actualSuccessor = helper.nextVisible(grandChild);
+
+      // then
+      expect(actualSuccessor).toEqual(lastChild);
+    });
+
+    it('returns null', () => {
+      // when
+      let actualSuccessor = helper.nextVisible(lastChild);
+
+      // then
+      expect(actualSuccessor).toEqual(null);
+    });
+
+    it('skips collapsed elements and returns next sibling element', () => {
+      // given
+      uiState.setExpanded(middleChild.path, false);
+      // when
+      let actualSuccessor = helper.nextVisible(middleChild);
+
+      // then
+      expect(actualSuccessor).toEqual(lastChild);
+    });
+  });
+
+  describe('nextSiblingOrAncestorSibling()', () => {
+
+    it('returns null for root', () => {
+      // when
+      let actualSuccessor = helper.nextSiblingOrAncestorSibling(null, workspace.root);
+
+      // then
+      expect(actualSuccessor).toEqual(null);
+    });
+
+    it('returns null last element', () => {
+      // when
+      let actualSuccessor = helper.nextSiblingOrAncestorSibling(workspace.root, lastChild);
+
+      // then
+      expect(actualSuccessor).toEqual(null);
+    });
+
+    it('returns next sibling', () => {
+      // when
+      let actualSuccessor = helper.nextSiblingOrAncestorSibling(workspace.root, firstChild);
+
+      // then
+      expect(actualSuccessor).toEqual(middleChild);
+    });
+
+    it('returns parent`s next sibling', () => {
+      // when
+      let actualSuccessor = helper.nextSiblingOrAncestorSibling(middleChild, grandChild);
+
+      // then
+      expect(actualSuccessor).toEqual(lastChild);
+    });
+  });
+
+  describe('previousVisible()', () => {
+    it('returns null for root', () => {
+      // when
+      let actualSuccessor = helper.previousVisible(workspace.root);
+
+      // then
+      expect(actualSuccessor).toEqual(null);
+    });
+
+    it('returns parent', () => {
+      // when
+      let actualSuccessor = helper.previousVisible(firstChild);
+
+      // then
+      expect(actualSuccessor).toEqual(workspace.root);
+    });
+
+    it('returns preceeding sibling', () => {
+      // when
+      let actualSuccessor = helper.previousVisible(middleChild);
+
+      // then
+      expect(actualSuccessor).toEqual(firstChild);
+    });
+
+    it('returns preceeding sibling`s last descendant', () => {
+      // when
+      let actualSuccessor = helper.previousVisible(lastChild);
+
+      // then
+      expect(actualSuccessor).toEqual(greatGrandChild);
+    });
+
+    it('skips collapsed elements and returns preceeding sibling', () => {
+      // given
+      uiState.setExpanded(middleChild.path, false);
+
+      // when
+      let actualSuccessor = helper.previousVisible(lastChild);
+
+      // then
+      expect(actualSuccessor).toEqual(middleChild);
+    });
+  });
+
+  describe('lastVisibleDescendant()', () => {
+    it('returns last child for root', () => {
+      // when
+      let actualSuccessor = helper.lastVisibleDescendant(workspace.root);
+
+      // then
+      expect(actualSuccessor).toEqual(lastChild);
+    });
+
+    it('returns itself when collapsed', () => {
+      // given
+      uiState.setExpanded(workspace.root.path, false);
+      // when
+      let actualSuccessor = helper.lastVisibleDescendant(workspace.root);
+
+      // then
+      expect(actualSuccessor).toEqual(workspace.root);
+    });
+
+    it('returns last descendant', () => {
+      // when
+      let actualSuccessor = helper.lastVisibleDescendant(middleChild);
+
+      // then
+      expect(actualSuccessor).toEqual(greatGrandChild);
+    });
+
+    it('returns last visible descendant', () => {
+      // given
+      uiState.setExpanded(grandChild.path, false);
+      // when
+      let actualSuccessor = helper.lastVisibleDescendant(middleChild);
+
+      // then
+      expect(actualSuccessor).toEqual(grandChild);
+    });
+  });
+});

--- a/src/lib/src/common/util/workspace.navigation.helper.ts
+++ b/src/lib/src/common/util/workspace.navigation.helper.ts
@@ -1,0 +1,56 @@
+import { UiState } from '../../component/ui-state';
+import { WorkspaceElement } from '../workspace-element';
+import { Workspace } from '../workspace';
+import { ElementType } from '../element-type';
+
+/**
+ * Helper class providing methods to navigate through the workspace tree, taking current UI state
+ * into account (e.g. not traversing folders which are collapsed in the tree view).
+ */
+export class WorkspaceNavigationHelper {
+
+  constructor(private readonly workspace: Workspace, private readonly uiState: UiState​​) {}
+
+  nextVisible(element: WorkspaceElement): WorkspaceElement {
+    if (element.children.length > 0 && this.uiState.isExpanded(element.path)) {
+      return element.children[0];
+    } else {
+      return this.nextSiblingOrAncestorSibling(this.workspace.getParent(element.path), element);
+    }
+  }
+
+  nextSiblingOrAncestorSibling(parent: WorkspaceElement, element: WorkspaceElement): WorkspaceElement {
+    let sibling = parent;
+    if (parent != null) {
+      let elementIndex = parent.children.indexOf(element);
+      if (elementIndex + 1 < parent.children.length) { // implicitly assuming elementIndex > -1
+        sibling = parent.children[elementIndex + 1];
+      } else {
+        sibling = this.nextSiblingOrAncestorSibling(this.workspace.getParent(parent.path), parent);
+      }
+    }
+    return sibling;
+  }
+
+  previousVisible(element: WorkspaceElement): WorkspaceElement {
+    let parent = this.workspace.getParent(element.path);
+    if (parent != null) {
+      let elementIndex = parent.children.indexOf(element);
+      if (elementIndex === 0) {
+        return parent;
+      } else {
+        return this.lastVisibleDescendant(parent.children[elementIndex - 1]);
+      }
+    }
+    return null;
+  }
+
+  lastVisibleDescendant(element: WorkspaceElement): WorkspaceElement {
+    if (element.type === ElementType.Folder && this.uiState.isExpanded(element.path)) {
+      return this.lastVisibleDescendant(element.children[element.children.length - 1]);
+    } else {
+      return element;
+    }
+  }
+
+}

--- a/src/lib/src/common/workspace.spec.data.ts
+++ b/src/lib/src/common/workspace.spec.data.ts
@@ -1,0 +1,51 @@
+import { WorkspaceElement } from './workspace-element';
+import { ElementType } from './element-type';
+import { Workspace } from './workspace';
+
+export const firstChild: WorkspaceElement = {
+  name: 'firstChild',
+  path: 'root/firstChild',
+  type: ElementType.File,
+  children: []
+};
+export const greatGrandChild: WorkspaceElement = {
+  name: 'greatGrandChild',
+  path: 'root/middleChild/grandChild/greatGrandChild',
+  type: ElementType.File,
+  children: []
+};
+export const grandChild: WorkspaceElement = {
+  name: 'grandChild',
+  path: 'root/middleChild/grandChild',
+  type: ElementType.Folder,
+  children: [greatGrandChild]
+};
+export const middleChild: WorkspaceElement = {
+  name: 'middleChild',
+  path: 'root/middleChild',
+  type: ElementType.Folder,
+  children: [grandChild]
+};
+export const lastChild: WorkspaceElement = {
+  name: 'lastChild',
+  path: 'root/lastChild',
+  type: ElementType.File,
+  children: []
+};
+
+/**
+ * + root
+ *   - firstChild
+ *   + middleChild
+ *     + grandChild
+ *       - greatGrandChild
+ *   - lastChild
+ */
+export function createWorkspaceWithSubElements(): Workspace {
+  return new Workspace({
+    name: 'folder',
+    path: 'root',
+    type: ElementType.Folder,
+    children: [firstChild, middleChild, lastChild]
+  });
+};

--- a/src/lib/src/common/workspace.spec.ts
+++ b/src/lib/src/common/workspace.spec.ts
@@ -1,6 +1,7 @@
 import { ElementType } from './element-type';
 import { Workspace } from './workspace';
 import { WorkspaceElement } from './workspace-element';
+import { grandChild, createWorkspaceWithSubElements, middleChild } from './workspace.spec.data';
 
 function createWorkspaceWithRootFolder(path: string): Workspace {
   let element: WorkspaceElement = {
@@ -11,38 +12,6 @@ function createWorkspaceWithRootFolder(path: string): Workspace {
   };
   return new Workspace(element);
 }
-
-const firstChild: WorkspaceElement = {
-  name: 'firstChild',
-  path: 'root/firstChild',
-  type: ElementType.File,
-  children: []
-};
-const grandChild: WorkspaceElement = {
-  name: 'grandChild',
-  path: 'root/middleChild/grandChild',
-  type: ElementType.File,
-  children: []
-};
-const middleChild: WorkspaceElement = {
-  name: 'middleChild',
-  path: 'root/middleChild',
-  type: ElementType.Folder,
-  children: [grandChild]
-};
-const lastChild: WorkspaceElement = {
-  name: 'lastChild',
-  path: 'root/lastChild',
-  type: ElementType.File,
-  children: []
-};
-const workspaceWithSubElements = new Workspace({
-  name: 'folder',
-  path: 'root',
-  type: ElementType.Folder,
-  children: [firstChild, middleChild, lastChild]
-});
-
 
 describe('Workspace', () => {
 
@@ -117,28 +86,29 @@ describe('Workspace.getParent()', () => {
         // given
         let path = grandChild.path;
         // when
-        let actualParent = workspaceWithSubElements.getParent(path);
+        let actualParent = createWorkspaceWithSubElements().getParent(path);
         // then
         expect(actualParent).toEqual(middleChild);
       });
 
-      it('returns undefined for the root element', () => {
+      it('returns null for the root element', () => {
         // given
-        let path = workspaceWithSubElements.root.path;
+        let workspace = createWorkspaceWithSubElements();
+        let path = workspace.root.path;
         // when
-        let actualParent = workspaceWithSubElements.getParent(path);
+        let actualParent = workspace.getParent(path);
         // then
-        expect(actualParent).toBeUndefined();
+        expect(actualParent).toBeNull();
       });
 
 
-      it('returns undefined for parent of empty path', () => {
+      it('returns null for parent of empty path', () => {
         // given
         let workspace = createWorkspaceWithRootFolder('/');
         // when
         let actualParent = workspace.getParent('');
         // then
-        expect(actualParent).toBeUndefined();
+        expect(actualParent).toBeNull();
       });
 
       it('returns root, if root´s normalized path is the empty string, for a path not containing any slashes', () => {

--- a/src/lib/src/common/workspace.ts
+++ b/src/lib/src/common/workspace.ts
@@ -50,7 +50,7 @@ export class Workspace {
     return this.pathToElement.get(normalized);
   }
 
-  getParent(path: string): WorkspaceElement | undefined {
+  getParent(path: string): WorkspaceElement {
     let normalized = this.normalizePath(path);
     if (normalized !== '') {
       let lastSeparatorIndex = normalized.lastIndexOf('/');
@@ -61,5 +61,6 @@ export class Workspace {
         return this.root;
       }
     }
+    return null;
   }
 }

--- a/src/lib/src/component/navigation/navigation.component.html
+++ b/src/lib/src/component/navigation/navigation.component.html
@@ -1,5 +1,5 @@
 <div class="sidenav noselect">
-  <div *ngIf="workspace">
+  <div *ngIf="getWorkspace()">
     <div class="icon-menu">
       <div class="icons-left">
         <button id="new-file" class="icon glyphicon glyphicon-file" (click)="newElement('file')" title="create new file"></button>
@@ -11,7 +11,7 @@
         <button id="collapse-all" class="icon fa fa-minus-square-o" aria-hidden="true" (click)="collapseAll()" title="collapse all"></button>
       </div>
     </div>
-    <nav-tree-viewer tabindex="0" [model]="workspace.root" [uiState]="uiState" (keyup)="onKeyUp($event)"></nav-tree-viewer>
+    <nav-tree-viewer tabindex="0" [model]="getWorkspace().root" [uiState]="uiState" (keyup)="onKeyUp($event)"></nav-tree-viewer>
   </div>
   <div *ngIf="errorMessage" id="errorMessage" class="alert alert-danger">{{errorMessage}}</div>
   <div *ngIf="notification" id="notification" class="alert alert-info">{{notification}}</div>

--- a/src/lib/src/component/navigation/navigation.component.test.setup.ts
+++ b/src/lib/src/component/navigation/navigation.component.test.setup.ts
@@ -82,6 +82,6 @@ export function setupWorkspace(component: NavigationComponent, fixture: Componen
     type: ElementType.Folder,
     children: [subfolder]
   };
-  component.workspace = new Workspace(root);
+  component.setWorkspace(new Workspace(root));
   fixture.detectChanges();
 }


### PR DESCRIPTION
…t tests

* introduced an enum for key actions
* introduced class `WorkspaceNavigationHelper`, providing methods for traversing the workspace tree.
    * this still is not ideal, since the class requires references to the current workspace, as well as the `UIState` instance. It is nice that `Workspace` is kept clean of `UIState` information, but the other way around there is clearly a dependency. Right now, the two classes are treated as more or less fully independent, being coupled together only by `NavigationComponent`.
* moved test data (exemplary workspace tree) into a separate file, `workspace.spec.data.ts`.
* ~set TypeScript version to 2.4.2, the same that is currently being used in [https://github.com/test-editor/test-editor-web](test-editor-web) (in fact, I just noticed there are two entries in its [yarn.lock](https://github.com/test-editor/test-editor-web/blob/a79596151853526d7140df211775903e2a74ca1a/yarn.lock#L5629) for the TypeScript dependency…!)~ TypeScript version is back to 2.3.0, because Angular 4.x does not seem to like TS > 2.3, and updating to Angular 5.x is a more complex matter. Since string enums are not supported in TS 2.3.0, `KeyActions` is now a class with `static readonly` fields, instead.
* broke up long key event dispatching method.
  