### PR TITLE
recognize image files and indicate with appropriate icon

### DIFF
--- a/src/lib/src/component/tree-viewer/tree-viewer.component.html
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.html
@@ -13,7 +13,8 @@
         'glyphicon-folder-close': isEmptyFolder(),
         'glyphicon-chevron-down': isFolderExpanded(),
         'glyphicon-chevron-right': isFolderFolded(),
-        'glyphicon-file': isFile()
+        'glyphicon-file': isFile(),
+        'glyphicon-picture': isImage()
       }" (click)="onIconClick()">
       </span> {{model.name}}
       <span *ngIf="level != 0" class="icon-delete glyphicon glyphicon-remove" (click)="onDeleteIconClick()"></span>

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -369,4 +369,51 @@ describe('TreeViewerComponent', () => {
     });
   }));
 
+  ['bmp', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'BMP', 'Png', 'jPeG'].forEach((extension) => {
+    it(`recognizes '${extension}' as image file name extension`, () => {
+      // given
+      let imageFilename = `image.${extension}`;
+      component.model = {
+        name: imageFilename, path: imageFilename, type: 'file', children: []
+      };
+
+      // when
+      let actual = component.isImage();
+
+      // then
+      expect(actual).toBeTruthy();
+    });
+  });
+
+  ['fileWithoutExtension', 'test.tcl', 'image.png.bak', 'i-am-no-jpeg'].forEach((filename) => {
+    it(`does not recognize '${filename}' as image`, () => {
+      // given
+      component.model = {
+        name: filename, path: filename, type: 'file', children: []
+      };
+
+      // when
+      let actual = component.isImage();
+
+      // then
+      expect(actual).toBeFalsy();
+    });
+  });
+
+  it('has picture icon for image files', () => {
+    // given
+    let imageFilename = 'image.jpg';
+    component.model = {
+      name: imageFilename, path: imageFilename, type: 'file', children: []
+    };
+    expect(component.isImage()).toBeTruthy();
+
+    // when
+    fixture.detectChanges();
+    let icon = getItemKey().query(By.css('.icon-type'));
+
+    // then
+    expect(icon.classes['glyphicon-picture']).toBeTruthy();
+  });
+
 });

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.ts
@@ -14,6 +14,8 @@ import { UiState } from '../ui-state';
 })
 export class TreeViewerComponent {
 
+  private static readonly IMAGE_EXTENSIONS = ['.bmp', '.png', '.jpg', '.jpeg', '.gif', '.svg'];
+
   @Input() uiState: UiState;
   @Input() model: WorkspaceElement;
   @Input() level: number = 0;
@@ -114,6 +116,12 @@ export class TreeViewerComponent {
       }
     }
     return false;
+  }
+
+  isImage(): boolean {
+    return TreeViewerComponent.IMAGE_EXTENSIONS.some((extension) => {
+      return this.model.path.toLowerCase().endsWith(extension);
+    }, this);
   }
 
 }


### PR DESCRIPTION
recognize images files by looking at their file name extensions (only '.bmp', '.png', '.jpg', '.jpeg', '.gif', and '.svg' are considered, for now), and show an appropriate icon as part of the corresponding navigator tree node.