### PR TITLE
Feature/indicate status

### DIFF
--- a/src/lib/src/common/element-state.ts
+++ b/src/lib/src/common/element-state.ts
@@ -1,4 +1,6 @@
 export const ElementState = {
-  Idle: "IDLE",
-  Running: "RUNNING"
-}
+  Idle: 'IDLE',
+  LastRunSuccessful: 'IDLE_LAST_RUN_SUCCESSFUL',
+  LastRunFailed: 'IDLE_LAST_RUN_FAILED',
+  Running: 'RUNNING'
+};

--- a/src/lib/src/component/navigation/navigation.component.spec.ts
+++ b/src/lib/src/component/navigation/navigation.component.spec.ts
@@ -211,7 +211,7 @@ describe('NavigationComponent', () => {
     let newElementRequest = component.uiState.newElementRequest;
     expect(newElementRequest).toBeTruthy();
     expect(newElementRequest.type).toEqual('folder');
-  })
+  });
 
   it('expands selected element on creation of new element', () => {
     // given

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.css
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.css
@@ -1,28 +1,29 @@
 .tree-view {
-	font-family: system-ui,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif;
-	font-size: 13px;
-	line-height: 22px;
+  font-family: system-ui, Segoe WPC, Segoe UI, HelveticaNeue-Light, Ubuntu, Droid Sans, sans-serif;
+  font-size: 13px;
+  line-height: 22px;
 }
 
-.tree-view-item {
-    display: block
-}
-
-.tree-view span.icon-type {
-	font-size: 10px;
+.tree-view .icon-type {
+  font-size: 10px;
   margin-right: 3px;
 }
 
 .header {
-    background-color: #363636;
-    color: #CCCCCC;
+  background-color: #363636;
+  color: #CCCCCC;
 }
 
 .tree-view-item {
-	text-decoration: none;
-  font-size: 15px;
-  width: 100%;
   cursor: pointer;
+  font-size: 15px;
+  text-decoration: none;
+  width: 100%;
+}
+
+.tree-view-item-key {
+  display: flex;
+  justify-content: space-between;
 }
 
 .tree-view-item-key:not(.selected) {
@@ -30,19 +31,19 @@
 }
 
 .tree-view-item-key:not(.active):not(.header):not(.selected):hover {
-    background-color: #2A2D2E;
+  background-color: #2A2D2E;
 }
 
 .active {
-    background-color: #3f3f46;
+  background-color: #3f3f46;
 }
 
 .dirty {
-    font-style: italic;
+  font-style: italic;
 }
 
 .dirty::after {
-    content: '*'
+  content: '*'
 }
 
 .selected:not(.header) {
@@ -52,20 +53,18 @@
 
 .alert {
   cursor: default;
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .icon-delete {
   color: #a80f22;
-  display: none;
   font-size: 12px;
-  float: right;
   right: 5px;
-  top: 5px;
+  visibility: hidden;
 }
 
 .tree-view-item:hover .icon-delete {
-  display: block;
+  visibility: visible;
 }
 
 .icon-delete:hover {

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.css
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.css
@@ -74,3 +74,11 @@
 .delete-confirm {
   margin-left: 40px;
 }
+
+.test-success {
+  color: #23d800;
+}
+
+.test-failure {
+  color: #d82300
+}

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.html
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.html
@@ -1,7 +1,6 @@
 <div class="tree-view" *ngIf="model">
   <div class="tree-view-item">
-    <div class="tree-view-item-key" (click)="onClick()" (dblclick)="onDoubleClick()"
-      [style.padding-left]="level * 12 + 'px'"
+    <div class="tree-view-item-key" (click)="onClick()" (dblclick)="onDoubleClick()" [style.padding-left]="level * 12 + 'px'"
       [ngClass]="{
         'active': model.path === uiState.activeEditorPath,
         'dirty': uiState.isDirty(model.path),
@@ -17,7 +16,12 @@
         'glyphicon-picture': isImage()
       }" (click)="onIconClick()">
       </span> {{model.name}}
-      <span *ngIf="level != 0" class="icon-delete glyphicon glyphicon-remove" (click)="onDeleteIconClick()"></span>
+      <span class="right-align">
+        <span id="test-state-running" [ngClass]="{
+          'fa-spinner fa-spin': isRunning(),
+          'fa fa-fw': true}"></span>
+        <span *ngIf="level != 0" class="icon-delete glyphicon glyphicon-remove" (click)="onDeleteIconClick()"></span>
+      </span>
     </div>
     <div *ngIf="confirmDelete" class="alert alert-warning confirm-delete">
       Are you sure you want to delete '{{model.name}}'?<br/>

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.html
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.html
@@ -23,7 +23,10 @@
 
       <div>
         <span id="test-state-running" class="fa fa-fw" [ngClass]="{
-          'fa-spinner fa-spin': isRunning()}"></span>
+          'fa-spinner fa-spin': isRunning(),
+          'fa-circle': lastRunSuccessful() || lastRunFailed(),
+          'test-success': lastRunSuccessful(),
+          'test-failure': lastRunFailed()}"></span>
         <span *ngIf="level != 0" class="icon-delete glyphicon glyphicon-remove" (click)="onDeleteIconClick()"></span>
       </div>
       

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.html
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.html
@@ -7,7 +7,9 @@
         'header': level == 0,
         'selected': model.path === uiState.selectedElement?.path
       }">
-      <span class="icon-type glyphicon" [ngClass]="{
+
+      <div>
+        <span class="icon-type glyphicon" [ngClass]="{
         'glyphicon-question-sign': isUnknown(),
         'glyphicon-folder-close': isEmptyFolder(),
         'glyphicon-chevron-down': isFolderExpanded(),
@@ -15,16 +17,20 @@
         'glyphicon-file': isFile(),
         'glyphicon-picture': isImage()
       }" (click)="onIconClick()">
-      </span> {{model.name}}
-      <span class="right-align">
-        <span id="test-state-running" [ngClass]="{
-          'fa-spinner fa-spin': isRunning(),
-          'fa fa-fw': true}"></span>
+        </span>
+        <span>{{model.name}}</span>
+      </div>
+
+      <div>
+        <span id="test-state-running" class="fa fa-fw" [ngClass]="{
+          'fa-spinner fa-spin': isRunning()}"></span>
         <span *ngIf="level != 0" class="icon-delete glyphicon glyphicon-remove" (click)="onDeleteIconClick()"></span>
-      </span>
+      </div>
+      
     </div>
     <div *ngIf="confirmDelete" class="alert alert-warning confirm-delete">
-      Are you sure you want to delete '{{model.name}}'?<br/>
+      Are you sure you want to delete '{{model.name}}'?
+      <br/>
       <a href="#" class="alert-link delete-cancel" (click)="onDeleteCancel()">No</a>
       <a href="#" class="alert-link delete-confirm" (click)="onDeleteConfirm()">Yes</a>
     </div>

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -491,4 +491,19 @@ describe('TreeViewerComponent', () => {
     expect(icon.classes['test-failure']).toBeFalsy();
   });
 
+  it('does not show any icon for non-executable files', () => {
+    // given
+    component.model = { name: 'file.txt', path: 'file.txt', type: 'file', children: [] };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    let icon = getItemKey().query(By.css('#test-state-running'));
+    expect(icon.classes['fa-spinner']).toBeFalsy();
+    expect(icon.classes['fa-circle']).toBeFalsy();
+    expect(icon.classes['test-success']).toBeFalsy();
+    expect(icon.classes['test-failure']).toBeFalsy();
+  });
+
 });

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -450,7 +450,33 @@ describe('TreeViewerComponent', () => {
     expect(icon.classes['fa-spinner']).toBeTruthy();
   });
 
-  it('does not show spinning icon for idle tests', () => {
+  it('shows appropriate indicator icon for failed tests', () => {
+    // given
+    component.model = { name: 'test.tcl', path: 'test.tcl', type: 'file', children: [], state: ElementState.LastRunFailed };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    let icon = getItemKey().query(By.css('#test-state-running'));
+    expect(icon.classes['fa-circle']).toBeTruthy();
+    expect(icon.classes['test-failure']).toBeTruthy();
+  });
+
+  it('shows appropriate indicator icon for successful tests', () => {
+    // given
+    component.model = { name: 'test.tcl', path: 'test.tcl', type: 'file', children: [], state: ElementState.LastRunSuccessful };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    let icon = getItemKey().query(By.css('#test-state-running'));
+    expect(icon.classes['fa-circle']).toBeTruthy();
+    expect(icon.classes['test-success']).toBeTruthy();
+  });
+
+  it('does not show any icon for idle tests without success/failure info', () => {
     // given
     component.model = { name: 'test.tcl', path: 'test.tcl', type: 'file', children: [], state: ElementState.Idle };
 
@@ -460,6 +486,9 @@ describe('TreeViewerComponent', () => {
     // then
     let icon = getItemKey().query(By.css('#test-state-running'));
     expect(icon.classes['fa-spinner']).toBeFalsy();
+    expect(icon.classes['fa-circle']).toBeFalsy();
+    expect(icon.classes['test-success']).toBeFalsy();
+    expect(icon.classes['test-failure']).toBeFalsy();
   });
 
 });

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -16,6 +16,7 @@ import { UiState } from '../ui-state';
 import * as events from '../event-types';
 import { WindowService } from '../../service/browserObjectModel/window.service';
 import { DefaultWindowService } from '../../service/browserObjectModel/default.window.service';
+import { ElementState } from '../../common/element-state';
 
 export function testBedSetup(providers?: any[]): void {
   TestBed.configureTestingModule({
@@ -435,6 +436,30 @@ describe('TreeViewerComponent', () => {
 
     // then
     expect(icon.classes['glyphicon-picture']).toBeTruthy();
+  });
+
+  it('shows spinning icon for running tests', () => {
+    // given
+    component.model = { name: 'test.tcl', path: 'test.tcl', type: 'file', children: [], state: ElementState.Running };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    let icon = getItemKey().query(By.css('#test-state-running'));
+    expect(icon.attributes['class']).toEqual('fa fa-spinner fa-spin');
+  });
+
+  it('does not show spinning icon for idle tests', () => {
+    // given
+    component.model = { name: 'test.tcl', path: 'test.tcl', type: 'file', children: [], state: ElementState.Idle };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    let icon = getItemKey().query(By.css('#test-state-running'));
+    expect(icon).toBeFalsy();
   });
 
 });

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -447,7 +447,7 @@ describe('TreeViewerComponent', () => {
 
     // then
     let icon = getItemKey().query(By.css('#test-state-running'));
-    expect(icon.attributes['class']).toEqual('fa fa-spinner fa-spin');
+    expect(icon.classes['fa-spinner']).toBeTruthy();
   });
 
   it('does not show spinning icon for idle tests', () => {
@@ -459,7 +459,7 @@ describe('TreeViewerComponent', () => {
 
     // then
     let icon = getItemKey().query(By.css('#test-state-running'));
-    expect(icon).toBeFalsy();
+    expect(icon.classes['fa-spinner']).toBeFalsy();
   });
 
 });

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.ts
@@ -7,6 +7,7 @@ import { PersistenceService } from '../../service/persistence/persistence.servic
 import * as events from '../event-types';
 import { UiState } from '../ui-state';
 import { WindowService } from '../../service/browserObjectModel/window.service';
+import { ElementState } from '../../common/element-state';
 
 @Component({
   selector: 'nav-tree-viewer',
@@ -132,6 +133,10 @@ export class TreeViewerComponent {
     return TreeViewerComponent.IMAGE_EXTENSIONS.some((extension) => {
       return this.model.path.toLowerCase().endsWith(extension);
     }, this);
+  }
+
+  isRunning(): boolean {
+    return this.model.state === ElementState.Running;
   }
 
 }

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.ts
@@ -135,8 +135,7 @@ export class TreeViewerComponent {
     }, this);
   }
 
-  isRunning(): boolean {
-    return this.model.state === ElementState.Running;
-  }
-
+  isRunning(): boolean { return this.model.state === ElementState.Running; }
+  lastRunSuccessful(): boolean { return this.model.state === ElementState.LastRunSuccessful; }
+  lastRunFailed(): boolean { return this.model.state === ElementState.LastRunFailed; }
 }


### PR DESCRIPTION
Workspace elements can now be in one of four states (see [element-state.ts](https://github.com/test-editor/web-workspace-navigator/blob/3aca462f6ed7c2c17f6aa9c029ad935cab46bce5/src/lib/src/common/element-state.ts)), which are indicated in the navigator with an icon next to it.

A running test case shows a spinning (animated) icon next to its workspace element in the navigator. A test that has run to completion successfully is indicated by a green circle, a test that has completed with errors / test failures shows a red circle. If a test is idle (not currently being executed), but no information about the success or failure of its last run is available, no specific icon is shown.