### PR TITLE
allow for problematic characters (e.g. ?) in filenames

### DIFF
--- a/src/lib/src/component/navigation/navigation.component.test.setup.ts
+++ b/src/lib/src/component/navigation/navigation.component.test.setup.ts
@@ -10,6 +10,7 @@ import { PersistenceService } from '../../service/persistence/persistence.servic
 import { TestExecutionService } from '../../service/execution/test.execution.service';
 import { Response, ResponseOptions } from '@angular/http';
 
+export const HTTP_STATUS_OK = 200;
 export const HTTP_STATUS_CREATED = 201;
 export const HTTP_STATUS_ERROR = 500;
 

--- a/src/lib/src/service/execution/test.execution.service.ts
+++ b/src/lib/src/service/execution/test.execution.service.ts
@@ -13,7 +13,8 @@ export class TestExecutionService {
   }
 
   execute(path: string): Promise<Response> {
-    let url = `${this.serviceUrl}?resource=${path}`;
+    let encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    let url = `${this.serviceUrl}?resource=${encodedPath}`;
     return this.http.post(url, '').toPromise();
   }
 

--- a/src/lib/src/service/persistence/persistence.service.spec.ts
+++ b/src/lib/src/service/persistence/persistence.service.spec.ts
@@ -1,6 +1,6 @@
-import { TestExecutionService } from './test.execution.service';
+import { PersistenceServiceConfig } from './persistence.service.config'
+import { PersistenceService } from './persistence.service'
 import { AuthHttp, AuthConfig } from 'angular2-jwt';
-import { TestExecutionServiceConfig } from './test.execution.service.config';
 import { Observable } from 'rxjs/Observable';
 import { Response, ResponseOptions, ConnectionBackend, XHRBackend, RequestMethod, HttpModule } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
@@ -8,14 +8,14 @@ import { Injector, ReflectiveInjector } from '@angular/core';
 import { inject } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { fakeAsync } from '@angular/core/testing';
-import { HTTP_STATUS_CREATED } from '../../component/navigation/navigation.component.test.setup';
+import { HTTP_STATUS_OK } from '../../component/navigation/navigation.component.test.setup';
 
 describe('TestExecutionService', () => {
-  let serviceConfig: TestExecutionServiceConfig;
+  let serviceConfig: PersistenceServiceConfig;
 
   beforeEach(() => {
-    serviceConfig = new TestExecutionServiceConfig();
-    serviceConfig.testExecutionServiceUrl = 'http://localhost:9080/tests/execute';
+    serviceConfig = new PersistenceServiceConfig();
+    serviceConfig.persistenceServiceUrl = 'http://localhost:9080';
     // dummy jwt token
     let authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M';
 
@@ -24,31 +24,31 @@ describe('TestExecutionService', () => {
       providers: [
         { provide: XHRBackend, useClass: MockBackend},
         { provide: AuthConfig, useValue: new AuthConfig({tokenGetter: () => authToken}) },
-        { provide: TestExecutionServiceConfig, useValue: serviceConfig },
-        TestExecutionService, AuthHttp
+        { provide: PersistenceServiceConfig, useValue: serviceConfig },
+        PersistenceService, AuthHttp
       ]
     });
   });
 
-  it('invokes REST endpoint with encoded path', fakeAsync(inject([XHRBackend, TestExecutionService],
-    (mockBackend: MockBackend, executionService: TestExecutionService) => {
+  it('invokes REST endpoint with encoded path', fakeAsync(inject([XHRBackend, PersistenceService],
+    (mockBackend: MockBackend, persistenceService: PersistenceService) => {
     // given
     let tclFilePath = 'path/to/file?.tcl';
     mockBackend.connections.subscribe(
       (connection: MockConnection) => {
-        expect(connection.request.method).toBe(RequestMethod.Post);
-        expect(connection.request.url).toBe(serviceConfig.testExecutionServiceUrl + '?resource=path/to/file%3F.tcl');
+        expect(connection.request.method).toBe(RequestMethod.Delete);
+        expect(connection.request.url).toBe(serviceConfig.persistenceServiceUrl + '/documents/path/to/file%3F.tcl');
 
-        connection.mockRespond(new Response( new ResponseOptions({status: HTTP_STATUS_CREATED})));
+        connection.mockRespond(new Response( new ResponseOptions({status: HTTP_STATUS_OK})));
       }
     );
 
     // when
-    executionService.execute(tclFilePath)
+    persistenceService.deleteResource(tclFilePath)
 
     // then
     .then(response => {
-      expect(response.status).toBe(HTTP_STATUS_CREATED);
+      expect(response.status).toBe(HTTP_STATUS_OK);
     });
   })));
 

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -36,7 +36,8 @@ export class PersistenceService {
   }
 
   getURL(path: string): string {
-    return `${this.serviceUrl}/documents/${path}`;
+    let encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    return `${this.serviceUrl}/documents/${encodedPath}`;
   }
 
 }


### PR DESCRIPTION
Had a problem with a file that was actually named '?'. It could not be deleted.