### PR TITLE
Feature/generic marker api

### DIFF
--- a/src/lib/src/common/markers/field.spec.ts
+++ b/src/lib/src/common/markers/field.spec.ts
@@ -5,7 +5,7 @@ import { ElementState } from '../element-state';
 describe('Field', () => {
   it('can be initialized', () => {
     const testField: Field = {
-      condition: (element) => element && element.name.endsWith('tcl'),
+      condition: (element) => element && element.name.endsWith('.tcl'),
       states: [{
         condition: (marker) => marker.testStatus === ElementState.Running,
         cssClasses: 'fa fa-spinner fa-spin',

--- a/src/lib/src/common/markers/field.spec.ts
+++ b/src/lib/src/common/markers/field.spec.ts
@@ -1,0 +1,26 @@
+import { Field } from './field.setup';
+import { ElementState } from '../element-state';
+
+
+describe('Field', () => {
+  it('can be initialized', () => {
+    const testField: Field = {
+      condition: (element) => element && element.name.endsWith('tcl'),
+      states: [{
+        condition: (marker) => marker.testStatus === ElementState.Running,
+        cssClasses: 'fa fa-spinner fa-spin',
+        label: (marker) => `Test "${marker.name}" is running`,
+      }, {
+        condition: (marker) => marker.testStatus === ElementState.LastRunSuccessful,
+        cssClasses: 'fa fa-circle test-success',
+        label: (marker) => `Last run of test "${marker.name}" was successful`,
+      }, {
+        condition: (marker) => marker.testStatus === ElementState.LastRunFailed,
+        cssClasses: 'fa fa-circle test-failure',
+        label: (marker) => `Last run of test "${marker.name}" has failed`,
+      }]
+    };
+  });
+});
+
+// exports['     <-- triggers SystemJS regex to trick it into applying CommonJS module wrapper

--- a/src/lib/src/common/markers/field.spec.ts
+++ b/src/lib/src/common/markers/field.spec.ts
@@ -1,4 +1,4 @@
-import { Field } from './field.setup';
+import { Field } from './field';
 import { ElementState } from '../element-state';
 
 

--- a/src/lib/src/common/markers/field.ts
+++ b/src/lib/src/common/markers/field.ts
@@ -1,0 +1,7 @@
+import { WorkspaceElement } from '../workspace-element';
+import { MarkerState } from './marker.state';
+
+export class Field {
+  condition: (element: WorkspaceElement) => boolean;
+  states: MarkerState[];
+}

--- a/src/lib/src/common/markers/marker.state.spec.ts
+++ b/src/lib/src/common/markers/marker.state.spec.ts
@@ -1,0 +1,42 @@
+import { ElementState } from '../element-state';
+import { MarkerState } from './marker.state';
+
+describe('MarkerState', () => {
+
+  let sampleMarkerState: MarkerState;
+
+  beforeEach(() => {
+    sampleMarkerState = {
+      condition: (marker) => marker.testStatus === ElementState.Running,
+      cssClasses: 'fa-spinner fa-spin',
+      label: (marker) => `Test ${marker.name} is running`,
+    };
+  });
+
+  it('conditions can be invoked', () => {
+    // given
+    const marker = { testStatus: ElementState.Running };
+
+    // when
+    const actualResult = sampleMarkerState.condition(marker);
+
+    // then
+    expect(actualResult).toBeTruthy();
+  });
+
+  it('returns the correct label', () => {
+    // given
+    const markerState: MarkerState = {
+      condition: (marker) => marker['testStatus'] === ElementState.Running,
+      cssClasses: 'fa-spinner fa-spin',
+      label: (marker) => `Test ${marker.name} is running`,
+    };
+    const marker = { name: 'sampleTest.tcl' };
+
+    // when
+    const actualLabel = markerState.label(marker);
+
+    // then
+    expect(actualLabel).toEqual('Test sampleTest.tcl is running');
+  });
+});

--- a/src/lib/src/common/markers/marker.state.spec.ts
+++ b/src/lib/src/common/markers/marker.state.spec.ts
@@ -27,8 +27,8 @@ describe('MarkerState', () => {
   it('returns the correct label', () => {
     // given
     const markerState: MarkerState = {
-      condition: (marker) => marker['testStatus'] === ElementState.Running,
-      cssClasses: 'fa-spinner fa-spin',
+      condition: () => true,
+      cssClasses: '',
       label: (marker) => `Test ${marker.name} is running`,
     };
     const marker = { name: 'sampleTest.tcl' };

--- a/src/lib/src/common/markers/marker.state.ts
+++ b/src/lib/src/common/markers/marker.state.ts
@@ -1,0 +1,5 @@
+export class MarkerState {
+  condition: (marker: any) => boolean;
+  cssClasses: string;
+  label: (marker: any) => string;
+}

--- a/src/lib/src/common/markers/marker.state.ts
+++ b/src/lib/src/common/markers/marker.state.ts
@@ -1,3 +1,11 @@
+/**
+ * Represents the state a marker field can assume based on a marker.
+ *
+ * The marker objects provided as parameters to the condition and
+ * the label functions are of arbitrary type: they will contain
+ * attributes corresponding to whatever properties have been added
+ * to the workspace element for which a field should be displayed.
+ */
 export class MarkerState {
   condition: (marker: any) => boolean;
   cssClasses: string;

--- a/src/lib/src/common/workspace-element.ts
+++ b/src/lib/src/common/workspace-element.ts
@@ -8,7 +8,7 @@ export class WorkspaceElementInfo {
 }
 
 export class LinkedWorkspaceElement extends WorkspaceElementInfo {
-  childPaths: string[]
+  childPaths: string[];
 }
 
 export class WorkspaceElement extends WorkspaceElementInfo {

--- a/src/lib/src/common/workspace.spec.ts
+++ b/src/lib/src/common/workspace.spec.ts
@@ -308,7 +308,7 @@ describe('Workspace marker interface', () => {
     workspace.setMarkerValue('some/other/path', 'anUnrelatedField', 'bar');
 
     // when
-    const actualMarker = workspace.getMarker('some/path');
+    const actualMarker = workspace.getMarkers('some/path');
 
     // then
     expect(actualMarker.aField).toEqual(42);
@@ -322,7 +322,7 @@ describe('Workspace marker interface', () => {
     workspace.setMarkerValue('some/other/path', 'anUnrelatedField', 'bar');
 
     // when
-    const actualMarker = workspace.getMarker('some/path');
+    const actualMarker = workspace.getMarkers('some/path');
 
     // then
     expect(actualMarker).toEqual({});

--- a/src/lib/src/common/workspace.ts
+++ b/src/lib/src/common/workspace.ts
@@ -12,6 +12,7 @@ export class Workspace {
   private root: WorkspaceElement = null;
   private uiState: UiState;
   private pathToElement = new Map<string, WorkspaceElement>();
+  private readonly markers: any[] = [];
 
   constructor() {
     this.uiState = new UiState();
@@ -24,7 +25,7 @@ export class Workspace {
       this.addToMap(this.root);
     }
   }
-  public get initialized() : boolean {
+  public get initialized(): boolean {
     return this.root != null;
   }
 
@@ -39,6 +40,48 @@ export class Workspace {
     const trailingSlashes = /\/+$/;
     let normalized = path.replace(leadingSlashes, '').replace(trailingSlashes, '');
     return normalized;
+  }
+
+  getMarkerValue(path: string, field: string): any {
+    return this.performIfNotNullOrUndefined('path', path, () => {
+      const marker = this.markers[path];
+      if (marker) {
+        if (marker[field] !== undefined) {
+          return marker[field];
+        } else {
+          throw new Error(`The marker field "${field}" does not exist for path "${path}".`);
+        }
+      } else {
+        throw new Error(`There are no marker fields for path "${path}".`);
+      }
+    });
+  }
+
+  getMarker(path: string): any {
+    return this.performIfNotNullOrUndefined('path', path, () => {
+      return this.markers[path] ? this.markers[path] : {};
+    });
+  }
+
+  setMarkerValue(path: string, field: string, value: any): void {
+    if (field && field !== '') {
+      this.performIfNotNullOrUndefined('path', path, () => {
+        if (!this.markers[path]) {
+          this.markers[path] = {};
+        }
+        this.markers[path][field] = value;
+      });
+    } else {
+      throw new Error('empty field names are not allowed');
+    }
+  }
+
+  private performIfNotNullOrUndefined(parameterName: string, parameterValue: any, action: () => any) {
+    if (parameterValue != null) {
+      return action();
+    } else {
+      throw new Error(`${parameterName} must not be ${parameterValue}`);
+    }
   }
 
   /**

--- a/src/lib/src/common/workspace.ts
+++ b/src/lib/src/common/workspace.ts
@@ -57,7 +57,7 @@ export class Workspace {
     });
   }
 
-  getMarker(path: string): any {
+  getMarkers(path: string): any {
     return this.performIfNotNullOrUndefined('path', path, () => {
       return this.markers[path] ? this.markers[path] : {};
     });

--- a/src/lib/src/component/tree-viewer/indicator.box.component.html
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.html
@@ -1,0 +1,1 @@
+<div [title]="label" [ngClass]="cssClasses"></div>

--- a/src/lib/src/component/tree-viewer/indicator.box.component.html
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.html
@@ -1,1 +1,1 @@
-<div [title]="label" [ngClass]="cssClasses"></div>
+<div [title]="label" [class]="cssClasses"></div>

--- a/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
@@ -27,7 +27,7 @@ describe('IndicatorBoxComponent', () => {
 
   @Component({
     selector: `host-component`,
-    template: `<indicator-box [model]="{'workspace': workspace,'path': path, 'states': states}"></indicator-box>`
+    template: `<indicator-box [model]="{'workspace': workspace,'path': path, 'possibleStates': states}"></indicator-box>`
   })
   class TestHostComponent {
     @ViewChild(IndicatorBoxComponent)

--- a/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
@@ -1,0 +1,93 @@
+import { async, TestBed, ComponentFixture } from '@angular/core/testing';
+import { IndicatorBoxComponent } from './indicator.box.component';
+import { By } from '@angular/platform-browser';
+import { MarkerState } from '../../common/markers/marker.state';
+import { ElementState } from '../../common/element-state';
+import { Workspace } from '../../common/workspace';
+
+describe('IndicatorBoxComponent', () => {
+  let component: IndicatorBoxComponent;
+  let fixture: ComponentFixture<IndicatorBoxComponent>;
+
+  const sampleMarkerStates: MarkerState[] = [{
+    condition: (marker) => marker.testStatus === ElementState.Running,
+    cssClasses: 'fa fa-spinner fa-spin',
+    label: (marker) => `Test "${marker.name}" is running`,
+  }, {
+    condition: (marker) => marker.testStatus === ElementState.LastRunSuccessful,
+    cssClasses: 'fa fa-circle test-success',
+    label: (marker) => `Last run of test "${marker.name}" was successful`,
+  }, {
+    condition: (marker) => marker.testStatus === ElementState.LastRunFailed,
+    cssClasses: 'fa fa-circle test-failure',
+    label: (marker) => `Last run of test "${marker.name}" has failed`,
+  }];
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        IndicatorBoxComponent
+      ],
+      imports: [
+      ],
+      providers: [
+        // { provide: PersistenceService, useValue: instance(persistenceService) },
+        // { provide: TestExecutionService, useValue: instance(executionService) },
+        // { provide: WindowService, useValue: null}
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IndicatorBoxComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('Can be instantiated', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('uses the active marker state`s label and css classes', () => {
+    // given
+    const samplePath = 'sample/path/to/test.tcl';
+    const workspace = new Workspace();
+    workspace.setMarkerValue(samplePath, 'testStatus', ElementState.Running);
+    workspace.setMarkerValue(samplePath, 'name', 'test');
+
+    component.workspace = workspace;
+    component.path = samplePath;
+    component.states = sampleMarkerStates;
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
+    expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Test "test" is running');
+    expect(indicatorBoxTag.classes['fa-spinner']).toBeTruthy();
+    expect(indicatorBoxTag.classes['fa-spin']).toBeTruthy();
+  });
+
+  it('changes label and css classes in accordance with changing marker states', () => {
+    // given
+    const samplePath = 'sample/path/to/test.tcl';
+    const workspace = new Workspace();
+    workspace.setMarkerValue(samplePath, 'testStatus', ElementState.Running);
+    workspace.setMarkerValue(samplePath, 'name', 'test');
+    component.workspace = workspace;
+    component.path = samplePath;
+    component.states = sampleMarkerStates;
+    fixture.detectChanges();
+
+    // when
+    workspace.setMarkerValue(samplePath, 'testStatus', ElementState.LastRunSuccessful);
+    fixture.detectChanges();
+
+    // then
+    const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
+    expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Last run of test "test" was successful');
+    expect(indicatorBoxTag.classes['fa-circle']).toBeTruthy();
+    expect(indicatorBoxTag.classes['test-success']).toBeTruthy();
+  });
+});

--- a/src/lib/src/component/tree-viewer/indicator.box.component.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.ts
@@ -8,11 +8,11 @@ import { MarkerState } from '../../common/markers/marker.state';
   styleUrls: ['./indicator.box.component.css']
 })
 export class IndicatorBoxComponent {
-  @Input() model: { workspace: Workspace, path: string, states: MarkerState[] };
+  @Input() model: { workspace: Workspace, path: string, possibleStates: MarkerState[] };
 
   get cssClasses(): string {
     if (this.isInitialized()) {
-      const activeState = this.model.states.find((state) => state.condition(this.getMarker()));
+      const activeState = this.model.possibleStates.find((state) => state.condition(this.getMarkers()));
       if (activeState != null) {
         return activeState.cssClasses;
       }
@@ -22,21 +22,21 @@ export class IndicatorBoxComponent {
 
   get label(): string {
     if (this.isInitialized()) {
-      const activeState = this.model.states.find((state) => state.condition(this.getMarker()));
+      const activeState = this.model.possibleStates.find((state) => state.condition(this.getMarkers()));
       if (activeState) {
-        return activeState.label(this.getMarker());
+        return activeState.label(this.getMarkers());
       }
     } else {
       return '';
     }
   }
 
-  private getMarker(): any {
-    return this.model.workspace.getMarker(this.model.path);
+  private getMarkers(): any {
+    return this.model.workspace.getMarkers(this.model.path);
   }
 
   private isInitialized(): boolean {
-    return this.model != null && this.model.path != null && this.model.states != null && this.model.workspace != null;
+    return this.model != null && this.model.path != null && this.model.possibleStates != null && this.model.workspace != null;
   }
 
 }

--- a/src/lib/src/component/tree-viewer/indicator.box.component.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Workspace } from '../../common/workspace';
 import { MarkerState } from '../../common/markers/marker.state';
 
@@ -8,32 +8,35 @@ import { MarkerState } from '../../common/markers/marker.state';
   styleUrls: ['./indicator.box.component.css']
 })
 export class IndicatorBoxComponent {
-  workspace: Workspace;
-  path: string;
+  @Input() model: { workspace: Workspace, path: string, states: MarkerState[] };
 
-  private cssClasses: any = {};
-  private labelProviders: {condition: (marker: any) => boolean, label: (marker: any) => string}[];
-
-  public set states(states: MarkerState[]) {
-    this.cssClasses = {};
-    states.forEach((state) => {
-      this.cssClasses[state.cssClasses] = () => state.condition(this.getMarker());
-    });
-    this.labelProviders = states.map((state) => {
-      return {condition: state.condition, label: state.label};
-    });
+  get cssClasses(): string {
+    if (this.isInitialized()) {
+      const activeState = this.model.states.find((state) => state.condition(this.getMarker()));
+      if (activeState != null) {
+        return activeState.cssClasses;
+      }
+    }
+    return '';
   }
 
-
   get label(): string {
-    const activeLabel = this.labelProviders.find((provider) => provider.condition(this.getMarker()));
-    if (activeLabel) {
-      return activeLabel.label(this.getMarker());
+    if (this.isInitialized()) {
+      const activeState = this.model.states.find((state) => state.condition(this.getMarker()));
+      if (activeState) {
+        return activeState.label(this.getMarker());
+      }
+    } else {
+      return '';
     }
   }
 
   private getMarker(): any {
-    return this.workspace.getMarker(this.path);
+    return this.model.workspace.getMarker(this.model.path);
+  }
+
+  private isInitialized(): boolean {
+    return this.model != null && this.model.path != null && this.model.states != null && this.model.workspace != null;
   }
 
 }

--- a/src/lib/src/component/tree-viewer/indicator.box.component.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { Workspace } from '../../common/workspace';
+import { MarkerState } from '../../common/markers/marker.state';
+
+@Component({
+  selector: 'indicator-box',
+  templateUrl: './indicator.box.component.html',
+  styleUrls: ['./indicator.box.component.css']
+})
+export class IndicatorBoxComponent {
+  workspace: Workspace;
+  path: string;
+
+  private cssClasses: any = {};
+  private labelProviders: {condition: (marker: any) => boolean, label: (marker: any) => string}[];
+
+  public set states(states: MarkerState[]) {
+    this.cssClasses = {};
+    states.forEach((state) => {
+      this.cssClasses[state.cssClasses] = () => state.condition(this.getMarker());
+    });
+    this.labelProviders = states.map((state) => {
+      return {condition: state.condition, label: state.label};
+    });
+  }
+
+
+  get label(): string {
+    const activeLabel = this.labelProviders.find((provider) => provider.condition(this.getMarker()));
+    if (activeLabel) {
+      return activeLabel.label(this.getMarker());
+    }
+  }
+
+  private getMarker(): any {
+    return this.workspace.getMarker(this.path);
+  }
+
+}


### PR DESCRIPTION
* ability to associate arbitrary values with a path in `Workspace` (`get/setMarkerValue`)
* ability to describe fields to be displayed next to entries in the navigator's tree view (`Field`)
* fields have states that are used to conditionally set their appearance (title and css classes; `MarkerState`)
* marker states make use of contextual information stored as marker values in the workspace, regarding the workspace element being represented
* for each defined field, `TreeViewerComponent` instantiates a new sub-component, `IndicatorBoxComponent`, to display those fields, and have it handle state changes.