### PR TITLE
fix screenshot popup blocking issue

### DIFF
--- a/src/lib/src/component/tree-viewer/tree-viewer.component.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.ts
@@ -54,9 +54,10 @@ export class TreeViewerComponent {
 
   openFile() {
     if (this.isImage()) {
-      this.persistenceService.getBinaryResource(this.elementPath).then((response) => {
-        let url = new URL(URL.createObjectURL(response.blob()));
-        this.windowReference.open(url);
+      this.windowReference.open(() => {
+        return this.persistenceService.getBinaryResource(this.elementPath).then((response) => {
+          return new URL(URL.createObjectURL(response.blob()));
+        });
       });
     } else {
       this.messagingService.publish(events.NAVIGATION_OPEN, {

--- a/src/lib/src/service/browserObjectModel/default.window.service.ts
+++ b/src/lib/src/service/browserObjectModel/default.window.service.ts
@@ -9,8 +9,9 @@ import { WindowService } from './window.service';
 export class DefaultWindowService implements WindowService {
   private readonly windowRef = window;
 
-  open(url: URL): void {
-    this.windowRef.open(url.toString());
+  open(getUrl: () => Promise<URL>): void {
+    const newWindow = this.windowRef.open('');
+    getUrl().then((url) => newWindow.document.write(`<html><body><img src="${url.toString()}"/></body></html>`));
   }
 
 }

--- a/src/lib/src/service/browserObjectModel/window.service.ts
+++ b/src/lib/src/service/browserObjectModel/window.service.ts
@@ -1,3 +1,3 @@
 export abstract class WindowService {
-  abstract open(url: URL): void;
+  abstract open(getUrl: () => Promise<URL>): void;
 }


### PR DESCRIPTION
A new window is now opened as an immediate result of a user action (double-clicking the tree-view element representing an image file), as opposed to after the callback to load the image from the server. The latter seems to be recognized by (some? many?) browsers and is interpreted as being a popup, whereas opening a new window as a direct result of a user action is generallly seen as acceptable, it seems.

The image is loaded afterwards. Setting the new window's location directly (i.e. `newWindow.location.href = …`) did not work (window remained empty), so now a bit of html including an image tag with the appropriate source URL is written to its document object, instead.

I was able to verify that this works in a Chrome browser (63.0.3239.132) that had shown the previous, unintended behavior of opening the new tab for a split-second only, before killing it again.