### PR TITLE
Refactor/workspace refresh message bus

### DIFF
--- a/integration/src/app/app.component.ts
+++ b/integration/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MessagingService } from '@testeditor/messaging-service';
 
 import * as events from '@testeditor/workspace-navigator';
+import { WorkspaceElement, PersistenceService } from '@testeditor/workspace-navigator';
 
 @Component({
   selector: 'integration-app',
@@ -13,12 +14,17 @@ export class AppComponent {
   lastSelected: any;
   lastOpened: any;
 
-  constructor(messagingService: MessagingService) {
+  constructor(messagingService: MessagingService, private persistenceService: PersistenceService) {
     messagingService.subscribe(events.NAVIGATION_SELECT, element => {
       this.lastSelected = element;
     });
     messagingService.subscribe(events.NAVIGATION_OPEN, element => {
       this.lastOpened = element;
+    });
+    messagingService.subscribe(events.WORKSPACE_RELOAD_REQUEST, () => {
+      this.persistenceService.listFiles().then((root: WorkspaceElement) => {
+        messagingService.publish(events.WORKSPACE_RELOAD_RESPONSE, root);
+      });
     });
   }
 

--- a/src/lib/src/common/workspace.spec.ts
+++ b/src/lib/src/common/workspace.spec.ts
@@ -505,6 +505,6 @@ describe('Workspace marker polling', () => {
 
     // then
     expect(invocations).toEqual(4);
-    expect(workspace.getMarkerValue(observer.path, observer.field)).toEqual(ElementState.LastRunSuccessful);
+    expect(workspace.getMarkerValue(observer.path, observer.field)).toEqual(state[invocations]);
   }));
 });

--- a/src/lib/src/component/event-types.ts
+++ b/src/lib/src/component/event-types.ts
@@ -7,3 +7,5 @@ export const NAVIGATION_OPEN = 'navigation.open';
 export const NAVIGATION_SELECT = 'navigation.select';
 export const WORKSPACE_MARKER_UPDATE = 'workspace.marker.update';
 export const WORKSPACE_MARKER_OBSERVE = 'workspace.marker.observe';
+export const WORKSPACE_RELOAD_REQUEST = 'workspace.reload.request';
+export const WORKSPACE_RELOAD_RESPONSE = 'workspace.reload.response';


### PR DESCRIPTION
Navigator publishes a bus message when needing to refresh the workspace, instead of contacting the persistence service directly. It then reacts to a response message on the bus to receive the updated workspace elements.

The persistence service still lives inside of this project; the next step would be moving it into test-editor-web.

This branch is based on unmerged previous changes, which should be reviewed and merged first, to ease reviewing this pull request:
* pull request [52](https://github.com/test-editor/web-workspace-navigator/pull/52)
* pull request [54](https://github.com/test-editor/web-workspace-navigator/pull/54)
* pull request [55](https://github.com/test-editor/web-workspace-navigator/pull/55)
* pull request [56](https://github.com/test-editor/web-workspace-navigator/pull/56)