### PR TITLE
group, right-align, and flex-layout indicator boxes

### DIFF
--- a/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.spec.ts
@@ -71,7 +71,7 @@ describe('IndicatorBoxComponent', () => {
     const actualCssClasses = hostComponent.indicatorBoxComponentUnderTest.cssClasses;
 
     // then
-    expect(actualCssClasses).toEqual('fa fa-spinner fa-spin');
+    expect(actualCssClasses).toEqual('fa fa-spinner fa-spin fa-fw');
   })
 
   it('uses the active marker state`s label and css classes', () => {
@@ -88,7 +88,7 @@ describe('IndicatorBoxComponent', () => {
     // then
     const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
     expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Test "test" is running');
-    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-spinner fa-spin');
+    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-spinner fa-spin fa-fw');
   });
 
   it('changes label and css classes in accordance with changing marker states', () => {
@@ -101,7 +101,7 @@ describe('IndicatorBoxComponent', () => {
     fixture.detectChanges();
     const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
     expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Test "test" is running');
-    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-spinner fa-spin');
+    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-spinner fa-spin fa-fw');
 
     // when
     hostComponent.workspace.setMarkerValue(hostComponent.path, 'testStatus', ElementState.LastRunSuccessful);
@@ -109,7 +109,7 @@ describe('IndicatorBoxComponent', () => {
 
     // then
     expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Last run of test "test" was successful');
-    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-circle test-success');
+    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-circle test-success fa-fw');
   });
 
   it('handles exceptions in condition expressions gracefully and allows other state to become active', () => {
@@ -130,7 +130,7 @@ describe('IndicatorBoxComponent', () => {
 
     // then
     const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
-    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-circle test-success');
+    expect(indicatorBoxTag.nativeElement.className).toEqual('fa fa-circle test-success fa-fw');
     expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('Last run of test "test" was successful');
   });
 
@@ -152,7 +152,7 @@ describe('IndicatorBoxComponent', () => {
 
     // then
     const indicatorBoxTag = fixture.debugElement.query(By.css('div'));
-    expect(indicatorBoxTag.nativeElement.className).toEqual('');
+    expect(indicatorBoxTag.nativeElement.className).toEqual('fa-fw');
     expect(indicatorBoxTag.nativeElement.attributes['title'].value).toEqual('');
   });
 });

--- a/src/lib/src/component/tree-viewer/indicator.box.component.ts
+++ b/src/lib/src/component/tree-viewer/indicator.box.component.ts
@@ -14,10 +14,10 @@ export class IndicatorBoxComponent {
     if (this.isInitialized()) {
       const activeState = this.getActiveState();
       if (activeState != null) {
-        return activeState.cssClasses;
+        return activeState.cssClasses + ' fa-fw';
       }
     }
-    return '';
+    return 'fa-fw';
   }
 
   get label(): string {

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.css
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.css
@@ -42,10 +42,6 @@
   font-style: italic;
 }
 
-.dirty::after {
-  content: '*'
-}
-
 .selected:not(.header) {
   background-color: #094771;
   color: #ffffff;

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.css
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.css
@@ -21,7 +21,7 @@
   width: 100%;
 }
 
-.tree-view-item-key {
+.tree-view-item-key, .indicator-boxes {
   display: flex;
   justify-content: space-between;
 }

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.html
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.html
@@ -21,17 +21,19 @@
         <span>{{elementInfo.name}}</span>
       </div>
 
-      <div *ngFor="let field of fields">
-        <ng-container *ngIf="shouldFieldBeShown(field) else emptyIndicatorBox">
-          <indicator-box [model]="{'workspace': workspace, 'path': elementInfo.path, 'possibleStates': field.states}"></indicator-box>
-        </ng-container>
-        <ng-template #emptyIndicatorBox>
-          <div class="fa-fw"></div>
-        </ng-template>
+      <div class="indicator-boxes">
+        <div *ngFor="let field of fields">
+          <ng-container *ngIf="shouldFieldBeShown(field) else emptyIndicatorBox">
+            <indicator-box [model]="{'workspace': workspace, 'path': elementInfo.path, 'possibleStates': field.states}"></indicator-box>
+          </ng-container>
+          <ng-template #emptyIndicatorBox>
+            <div class="fa-fw"></div>
+          </ng-template>
+        </div>
+        <div>
+          <span *ngIf="level != 0" class="icon-delete fa fa-fw fa-times" (click)="onDeleteIconClick()"></span>
+        </div>
       </div>
-      <div>
-        <span *ngIf="level != 0" class="icon-delete fa fa-times" (click)="onDeleteIconClick()"></span>
-    </div>
 
     </div>
     <div *ngIf="confirmDelete" class="alert alert-warning confirm-delete">


### PR DESCRIPTION
This should ensure that all indicator boxes have the same, fixed width (`fa-fw`), and the indicator boxes as a whole are aligned to the right.