### PR TITLE
export marker.observer

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,3 +9,4 @@ export { TestExecutionService } from './src/service/execution/test.execution.ser
 export * from './src/component/event-types';
 export { Field, IndicatorFieldSetup } from './src/common/markers/field';
 export { MarkerState } from './src/common/markers/marker.state';
+export { MarkerObserver } from './src/common/markers/marker.observer';


### PR DESCRIPTION
marker observer is currently referenced by test-editor-web via path to the source element 