### PR TITLE
Feature/handle conflicts

### DIFF
--- a/src/lib/src/component/tree-viewer/new-element.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/new-element.component.spec.ts
@@ -13,6 +13,10 @@ import { NewElementComponent } from './new-element.component';
 import { UiState } from '../ui-state';
 import * as events from '../event-types';
 import { Workspace } from '../../common/workspace';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
+import { Conflict } from '../../service/persistence/conflict';
 
 describe('NewElementComponent', () => {
 
@@ -169,7 +173,7 @@ describe('NewElementComponent', () => {
     // given
     let callback = jasmine.createSpy('callback');
     messagingService.subscribe(events.NAVIGATION_CREATED, callback);
-    when(persistenceService.createResource(anyString(), anyString())).thenReturn(Promise.resolve('some/path'));
+    when(persistenceService.createResource(anyString(), anyString())).thenReturn(Observable.of('some/path'));
 
     // when
     component.onEnter();
@@ -185,7 +189,7 @@ describe('NewElementComponent', () => {
 
   it('signals an error when createDocument failed', async(() => {
     // given
-    when(persistenceService.createResource(anyString(), anyString())).thenReturn(Promise.reject('failed'));
+    when(persistenceService.createResource(anyString(), anyString())).thenReturn(Observable.throw('failed'));
 
     // when
     component.onEnter();
@@ -195,6 +199,25 @@ describe('NewElementComponent', () => {
       fixture.whenStable().then(() => {
         expect(component.errorMessage).toBeTruthy();
       });
+    });
+  }));
+
+  it('emits persistence.conflict event when createDocument returns with a conflict', async(() => {
+    // given
+    const conflict = new Conflict(`The file 'something-new.txt' already exists.`)
+    let callback = jasmine.createSpy('callback');
+    messagingService.subscribe(events.CONFLICT, callback);
+    when(persistenceService.createResource(anyString(), anyString())).thenReturn(Observable.of(conflict));
+
+    // when
+    component.onEnter();
+
+    // then
+    fixture.whenStable().then(() => {
+      expect(callback).toHaveBeenCalledTimes(1);
+      let expectedPayload = jasmine.objectContaining(conflict);
+      expect(callback).toHaveBeenCalledWith(expectedPayload);
+      expect(component.workspace.hasNewElementRequest()).toBeFalsy();
     });
   }));
 

--- a/src/lib/src/component/tree-viewer/new-element.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/new-element.component.spec.ts
@@ -202,12 +202,13 @@ describe('NewElementComponent', () => {
     });
   }));
 
-  it('emits persistence.conflict event when createDocument returns with a conflict', async(() => {
+  it('displays error and refreshes workspace when createDocument returns with a conflict', async(() => {
     // given
     const conflict = new Conflict(`The file 'something-new.txt' already exists.`)
     let callback = jasmine.createSpy('callback');
-    messagingService.subscribe(events.CONFLICT, callback);
+    messagingService.subscribe(events.NAVIGATION_CREATED, callback);
     when(persistenceService.createResource(anyString(), anyString())).thenReturn(Observable.of(conflict));
+    component.input.nativeElement.value = 'path/to/fileThatAlreadyExists'
 
     // when
     component.onEnter();
@@ -215,9 +216,10 @@ describe('NewElementComponent', () => {
     // then
     fixture.whenStable().then(() => {
       expect(callback).toHaveBeenCalledTimes(1);
-      let expectedPayload = jasmine.objectContaining(conflict);
+      let expectedPayload = jasmine.objectContaining({ path: 'path/to/fileThatAlreadyExists' });
       expect(callback).toHaveBeenCalledWith(expectedPayload);
-      expect(component.workspace.hasNewElementRequest()).toBeFalsy();
+      expect(component.errorMessage).toEqual(conflict.message);
+      expect(component.input.nativeElement.value).toEqual('');
     });
   }));
 

--- a/src/lib/src/component/tree-viewer/new-element.component.ts
+++ b/src/lib/src/component/tree-viewer/new-element.component.ts
@@ -57,14 +57,16 @@ export class NewElementComponent implements AfterViewInit {
 
   private sendCreateRequest(newPath: string, type: string): void {
     this.persistenceService.createResource(newPath, type).subscribe(result => {
-      this.remove();
+      let createdPath: string;
       if (isConflict(result)) {
-        this.messagingService.publish(events.CONFLICT, result);
+        this.errorMessage = result.message;
+        this.input.nativeElement.value = '';
+        createdPath = newPath;
       } else {
-        this.messagingService.publish(events.NAVIGATION_CREATED, {
-            path: <string>result
-        });
+        this.remove();
+        createdPath = result;
       }
+      this.messagingService.publish(events.NAVIGATION_CREATED, { path: createdPath });
     }, () => this.errorMessage = 'Error while creating element!');
   }
 

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -415,7 +415,7 @@ describe('TreeViewerComponent', () => {
     tick();
     fixture.detectChanges();
     expect(component.errorMessage).toEqual(conflict.message);
-    let errorMessage = fixture.debugElement.query(By.css('.tree-view-item .alert'));
+    const errorMessage = fixture.debugElement.query(By.css('.tree-view-item .alert'));
     expect(errorMessage).toBeTruthy();
     flush();
   }));

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, inject, fakeAsync, tick, flush } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -403,27 +403,22 @@ describe('TreeViewerComponent', () => {
     });
   });
 
-  it('displays error when deleted file is updated', (done: () => void) => {
+  it('displays error when deleteDocument returns with a conflict', fakeAsync(() => {
 
-    const conflict = new Conflict(`The file 'something-new.txt' already exists.`)
-    let callback = jasmine.createSpy('callback');
-    messagingService.subscribe(events.CONFLICT, callback);
+    const conflict = new Conflict(`The file 'something-new.txt' already exists.`);
     when(persistenceService.deleteResource(anyString())).thenReturn(Observable.of(conflict));
 
     // when
     component.onDeleteConfirm();
 
     // then
-    fixture.whenStable().then(() => {
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        expect(component.errorMessage).toEqual(conflict.message);
-        let errorMessage = fixture.debugElement.query(By.css('.tree-view-item .alert'));
-        expect(errorMessage).toBeTruthy();
-        done();
-      })
-    });
-  });
+    tick();
+    fixture.detectChanges();
+    expect(component.errorMessage).toEqual(conflict.message);
+    let errorMessage = fixture.debugElement.query(By.css('.tree-view-item .alert'));
+    expect(errorMessage).toBeTruthy();
+    flush();
+  }));
 
   it('removes confirmation and emits navigation.deleted event when deletion succeeds', async(() => {
     // given

--- a/src/lib/src/component/tree-viewer/tree-viewer.component.ts
+++ b/src/lib/src/component/tree-viewer/tree-viewer.component.ts
@@ -11,6 +11,7 @@ import { Workspace } from '../../common/workspace';
 import { LinkedWorkspaceElement } from '../../common/workspace-element';
 import { Field, IndicatorFieldSetup } from '../../common/markers/field';
 import { MarkerState } from '../../common/markers/marker.state';
+import { isConflict } from '../../service/persistence/conflict';
 
 @Component({
   selector: 'nav-tree-viewer',
@@ -91,16 +92,20 @@ export class TreeViewerComponent {
   }
 
   onDeleteConfirm(): void {
-    this.persistenceService.deleteResource(this.elementPath).then(() => {
-      this.messagingService.publish(events.NAVIGATION_DELETED, this.elementInfo);
-    }).catch(() => {
-      this.handleDeleteFailed();
+    this.persistenceService.deleteResource(this.elementPath).subscribe(result =>  {
+      if (isConflict(result)) {
+        this.handleDeleteFailed(result.message);
+      } else {
+        this.messagingService.publish(events.NAVIGATION_DELETED, this.elementInfo);
+      }
+    } , () => {
+      this.handleDeleteFailed('Error while deleting element!');
     });
     this.confirmDelete = false;
   }
 
-  handleDeleteFailed(): void {
-    this.errorMessage = 'Error while deleting element!';
+  handleDeleteFailed(message: string): void {
+    this.errorMessage = message;
     setTimeout(() => {
       this.errorMessage = null;
     }, 3000);
@@ -132,7 +137,7 @@ export class TreeViewerComponent {
   }
 
   isEmptyFolder(): boolean {
-    return this.elementInfo.childPaths.length == 0 && this.isFolder();
+    return this.elementInfo.childPaths.length === 0 && this.isFolder();
   }
 
   isUnknown(): boolean {
@@ -143,9 +148,9 @@ export class TreeViewerComponent {
     if (this.workspace.hasNewElementRequest()) {
       let selectedElement = this.workspace.getNewElement();
       if (selectedElement) {
-        return selectedElement.path == this.elementPath;
+        return selectedElement.path === this.elementPath;
       } else {
-        return this.level == 0; // display at root
+        return this.level === 0; // display at root
       }
     }
     return false;

--- a/src/lib/src/service/persistence/conflict.ts
+++ b/src/lib/src/service/persistence/conflict.ts
@@ -1,0 +1,9 @@
+// TODO remove this file (which was copied over from test-editor-web) and refactor its usages out into test-editor-web
+
+export class Conflict {
+  constructor(readonly message: string, readonly backupFilePath?: string) { }
+}
+
+export function isConflict(conflict: Conflict | {}): conflict is Conflict {
+  return (<Conflict>conflict).message !== undefined;
+}

--- a/src/lib/src/service/persistence/conflict.ts
+++ b/src/lib/src/service/persistence/conflict.ts
@@ -4,6 +4,6 @@ export class Conflict {
   constructor(readonly message: string, readonly backupFilePath?: string) { }
 }
 
-export function isConflict(conflict: Conflict | {}): conflict is Conflict {
+export function isConflict(conflict: Conflict | string): conflict is Conflict {
   return (<Conflict>conflict).message !== undefined;
 }

--- a/src/lib/src/service/persistence/persistence.service.spec.ts
+++ b/src/lib/src/service/persistence/persistence.service.spec.ts
@@ -66,7 +66,7 @@ describe('PersistenceService', () => {
     });
 
     const actualRequest = httpMock.expectOne({ method: 'POST' });
-    expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
+    expect(actualRequest.request.url).toEqual(url);
     expect(actualRequest.request.params.get('type')).toEqual('file');
     actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
   }));
@@ -91,7 +91,7 @@ describe('PersistenceService', () => {
     });
 
     const actualRequest = httpMock.expectOne({ method: 'DELETE' });
-    expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
+    expect(actualRequest.request.url).toEqual(url);
     actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
   }));
 });

--- a/src/lib/src/service/persistence/persistence.service.spec.ts
+++ b/src/lib/src/service/persistence/persistence.service.spec.ts
@@ -29,69 +29,69 @@ describe('PersistenceService', () => {
 
   it('invokes REST endpoint with encoded path', fakeAsync(inject([HttpTestingController, PersistenceService],
     (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
-      // given
-      let tclFilePath = 'path/to/file?.tcl';
+    // given
+    let tclFilePath = 'path/to/file?.tcl';
 
-      // when
-      persistenceService.deleteResource(tclFilePath)
+    // when
+    persistenceService.deleteResource(tclFilePath)
 
-        // then
-        .subscribe(response => {
-          expect(response).toBe('');
-        });
+      // then
+      .subscribe(response => {
+        expect(response).toBe('');
+      });
 
-      httpMock.match({
-        method: 'DELETE',
-        url: serviceConfig.persistenceServiceUrl + '/documents/path/to/file%3F.tcl'
-      })[0].flush('');
-    })));
+    httpMock.match({
+      method: 'DELETE',
+      url: serviceConfig.persistenceServiceUrl + '/documents/path/to/file%3F.tcl'
+    })[0].flush('');
+  })));
 
-    it('createResource returns Conflict object if HTTP status code is CONFLICT',
-      inject([HttpTestingController, PersistenceService],
-      (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
-        // given
-        let tclFilePath = 'path/to/file.tcl';
-        const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
-        const message = `The file '${tclFilePath}' already exists.`;
-        const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
+  it('createResource returns Conflict object if HTTP status code is CONFLICT',
+    inject([HttpTestingController, PersistenceService],
+    (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+    // given
+    let tclFilePath = 'path/to/file.tcl';
+    const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
+    const message = `The file '${tclFilePath}' already exists.`;
+    const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
 
-        const expectedResult = new Conflict(message);
+    const expectedResult = new Conflict(message);
 
-        // when
-        const actualObservableResult = persistenceService.createResource(tclFilePath, 'file');
+    // when
+    const actualObservableResult = persistenceService.createResource(tclFilePath, 'file');
 
-        // then
-        actualObservableResult.subscribe(actualResult => {
-          expect(actualResult).toEqual(expectedResult);
-        });
+    // then
+    actualObservableResult.subscribe(actualResult => {
+      expect(actualResult).toEqual(expectedResult);
+    });
 
-        const actualRequest = httpMock.expectOne({ method: 'POST' });
-        expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
-        expect(actualRequest.request.params.get('type')).toEqual('file');
-        actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
-      }));
+    const actualRequest = httpMock.expectOne({ method: 'POST' });
+    expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
+    expect(actualRequest.request.params.get('type')).toEqual('file');
+    actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
+  }));
 
-      it('deleteResource returns Conflict object if HTTP status code is CONFLICT',
-      inject([HttpTestingController, PersistenceService],
-      (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
-        // given
-        let tclFilePath = 'path/to/file.tcl';
-        const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
-        const message = `The file '${tclFilePath}' does not exist.`;
-        const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
+  it('deleteResource returns Conflict object if HTTP status code is CONFLICT',
+    inject([HttpTestingController, PersistenceService],
+    (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+    // given
+    let tclFilePath = 'path/to/file.tcl';
+    const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
+    const message = `The file '${tclFilePath}' does not exist.`;
+    const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
 
-        const expectedResult = new Conflict(message);
+    const expectedResult = new Conflict(message);
 
-        // when
-        const actualObservableResult = persistenceService.deleteResource(tclFilePath);
+    // when
+    const actualObservableResult = persistenceService.deleteResource(tclFilePath);
 
-        // then
-        actualObservableResult.subscribe(actualResult => {
-          expect(actualResult).toEqual(expectedResult);
-        });
+    // then
+    actualObservableResult.subscribe(actualResult => {
+      expect(actualResult).toEqual(expectedResult);
+    });
 
-        const actualRequest = httpMock.expectOne({ method: 'DELETE' });
-        expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
-        actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
-      }));
+    const actualRequest = httpMock.expectOne({ method: 'DELETE' });
+    expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
+    actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
+  }));
 });

--- a/src/lib/src/service/persistence/persistence.service.spec.ts
+++ b/src/lib/src/service/persistence/persistence.service.spec.ts
@@ -1,15 +1,16 @@
 import { PersistenceServiceConfig } from './persistence.service.config'
 import { PersistenceService } from './persistence.service'
 import { Observable } from 'rxjs/Observable';
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientModule, HttpClient, HttpResponse } from '@angular/common/http';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injector } from '@angular/core';
 import { inject } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { fakeAsync } from '@angular/core/testing';
 import { HTTP_STATUS_OK } from '../../component/navigation/navigation.component.test.setup';
+import { Conflict } from './conflict';
 
-describe('PersistenceExecutionService', () => {
+describe('PersistenceService', () => {
   let serviceConfig: PersistenceServiceConfig;
 
   beforeEach(() => {
@@ -45,4 +46,28 @@ describe('PersistenceExecutionService', () => {
       })[0].flush('');
     })));
 
+    it('createResource returns Conflict object if HTTP status code is CONFLICT',
+      inject([HttpTestingController, PersistenceService],
+      (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+        // given
+        let tclFilePath = 'path/to/file.tcl';
+        const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
+        const message = `The file '${tclFilePath}' already exists.`;
+        const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
+
+        const expectedResult = new Conflict(message);
+
+        // when
+        const actualObservableResult = persistenceService.createResource(tclFilePath, 'file')
+
+        // then
+        actualObservableResult.subscribe(actualResult => {
+          expect(actualResult).toEqual(expectedResult);
+        });
+
+        const actualRequest = httpMock.expectOne({ method: 'POST' });
+        expect(actualRequest.request.url).toEqual('http://localhost:9080/documents/path/to/file.tcl');
+        expect(actualRequest.request.params.get('type')).toEqual('file');
+        actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
+      }));
 });

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -52,7 +52,6 @@ export class PersistenceService {
   }
 
   deleteResource(path: string): Observable<string | Conflict> {
-    // return this.httpClient.delete(this.getURL(path), {responseType: 'text'}).toPromise();
     return this.getHttpClient().delete(this.getURL(path),  {
       observe: 'response',
       responseType: 'text',

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -2,9 +2,15 @@ import { Injectable, Injector } from '@angular/core';
 import { HttpClient, HttpClientModule }  from '@angular/common/http';
 import { WorkspaceElement } from '../../common/workspace-element';
 import { PersistenceServiceConfig } from './persistence.service.config';
+import { Conflict } from './conflict';
 
 import 'rxjs/add/operator/toPromise';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/catch';
 
+export const HTTP_STATUS_NO_CONTENT = 204;
+export const HTTP_STATUS_CONFLICT = 409;
+export const HTTP_HEADER_CONTENT_LOCATION = 'content-location';
 @Injectable()
 export class PersistenceService {
 
@@ -29,8 +35,18 @@ export class PersistenceService {
     return this.getHttpClient().get<WorkspaceElement>(this.listFilesUrl).toPromise();
   }
 
-  createResource(path: string, type: string): Promise<string> {
-    return this.getHttpClient().post(this.getURL(path), '', { responseType: 'text', params: { type: type } }).toPromise();
+  createResource(path: string, type: string): Observable<string | Conflict> {
+    return this.getHttpClient().post(this.getURL(path), '', {
+      observe: 'response',
+      responseType: 'text',
+      params: { type: type }
+    }).map(response => response.body).catch(response => {
+      if (response.status === HTTP_STATUS_CONFLICT) {
+        return Observable.of(new Conflict(response.error));
+      } else {
+        Observable.throw(new Error(response.body));
+      }
+    });
   }
 
   deleteResource(path: string): Promise<string> {

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -4,9 +4,11 @@ import { WorkspaceElement } from '../../common/workspace-element';
 import { PersistenceServiceConfig } from './persistence.service.config';
 import { Conflict } from './conflict';
 
+
 import 'rxjs/add/operator/toPromise';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/of';
 
 export const HTTP_STATUS_NO_CONTENT = 204;
 export const HTTP_STATUS_CONFLICT = 409;
@@ -44,13 +46,23 @@ export class PersistenceService {
       if (response.status === HTTP_STATUS_CONFLICT) {
         return Observable.of(new Conflict(response.error));
       } else {
-        Observable.throw(new Error(response.body));
+        Observable.throw(new Error(response.error));
       }
     });
   }
 
-  deleteResource(path: string): Promise<string> {
-    return this.getHttpClient().delete(this.getURL(path), {responseType: 'text'}).toPromise();
+  deleteResource(path: string): Observable<string | Conflict> {
+    // return this.httpClient.delete(this.getURL(path), {responseType: 'text'}).toPromise();
+    return this.getHttpClient().delete(this.getURL(path),  {
+      observe: 'response',
+      responseType: 'text',
+      }).map(response => response.body).catch(response => {
+      if (response.status === HTTP_STATUS_CONFLICT) {
+        return Observable.of(new Conflict(response.error));
+      } else {
+        Observable.throw(new Error(response.error));
+      }
+    });
   }
 
   getBinaryResource(path: string): Promise<Blob> {

--- a/src/lib/src/service/persistence/persistence.service.ts
+++ b/src/lib/src/service/persistence/persistence.service.ts
@@ -42,7 +42,8 @@ export class PersistenceService {
       observe: 'response',
       responseType: 'text',
       params: { type: type }
-    }).map(response => response.body).catch(response => {
+    }).map(response => response.body)
+    .catch(response => {
       if (response.status === HTTP_STATUS_CONFLICT) {
         return Observable.of(new Conflict(response.error));
       } else {
@@ -55,7 +56,8 @@ export class PersistenceService {
     return this.getHttpClient().delete(this.getURL(path),  {
       observe: 'response',
       responseType: 'text',
-      }).map(response => response.body).catch(response => {
+      }).map(response => response.body)
+      .catch(response => {
       if (response.status === HTTP_STATUS_CONFLICT) {
         return Observable.of(new Conflict(response.error));
       } else {


### PR DESCRIPTION
error message is shown (embedded in the tree view) when
* trying to create a file that already exists and is not empty, and
* trying to delete a file that was remotely modified.

Creating a file that already exists, but is also empty, does not raise an error – in this case, Git can automatically merge. The same goes for trying to delete files that have concurrently been deleted.

Not covered (here):
* opening text files that do not exist (have been remotely deleted); this is not really a conflict, and the existing behavior (showing an error message inside the read-only editor window) remains in place. However, the workspace should be refreshed, so that remains to be implemented.
* opening binary files that do not exist. This case is not handled at all.